### PR TITLE
Remove unused typedef

### DIFF
--- a/src/obj.h
+++ b/src/obj.h
@@ -7,7 +7,6 @@
 #include <stdint.h>
 
 typedef uint32_t UWord;
-typedef  int32_t SWord;
 
 struct obj {
     union {


### PR DESCRIPTION
I can't find a place where the type `SWord` (defined in [src/obj.c](https://github.com/kulp/tenyr/blob/master/src/obj.h#L10)) is actually used in any of the tenyr codebase. Unless there's a reason for keeping it around that I don't know about, I propose for it to be removed to reduce needless cluttering of the type namespace.
