### PR TITLE
Fix segfault during disassembly

### DIFF
--- a/src/asm.c
+++ b/src/asm.c
@@ -47,7 +47,7 @@ static int is_printable(int ch, size_t len, char buf[len])
         case '\r': buf[0] = '\\'; buf[1] = 'r' ; return 1;
         case '\t': buf[0] = '\\'; buf[1] = 't' ; return 1;
         case '\v': buf[0] = '\\'; buf[1] = 'v' ; return 1;
-        default: buf[0] = ch; return isprint(ch);
+        default: buf[0] = ch; return isprint((unsigned char)ch);
     }
 }
 


### PR DESCRIPTION
This fix addresses a segmentation fault that I was experiencing on my Ubuntu 12.04 LTS amd64 machine. The input of some words may not be representable as an unsigned char (or EOF), so the explicit cast is necessary to ensure defined behavior.
