### PR TITLE
Remove non-portable `raw` format

### DIFF
--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -117,7 +117,9 @@ check_args_specific_%: %$(EXE_SUFFIX) ;
 
 check_args_specific_tas: check_args_specific_%: %$(EXE_SUFFIX)
 	@$(MAKESTEP) "Checking $* specific options ... "
+	echo 0x3637 | $($*) -ftext -d - | grep -q ".word 0x0*3637"   && $(MAKESTEP) "    ... -d ok"
 	(! $($*) -f does_not_exist /dev/null &> /dev/null )          && $(MAKESTEP) "    ... -f ok"
+	echo 0x3637 | $($*) -ftext -d -q - | fgrep -qv "word 0x3637" && $(MAKESTEP) "    ... -q ok"
 	$($*) -d -ftext -v - <<<0xc | fgrep -q "A + 0x0000000c"      && $(MAKESTEP) "    ... -v ok"
 	echo '.zero 2' | $($*) -fmemh -pformat.memh.explicit=1 - | fgrep -q "@0 00000000" \
 	                                                             && $(MAKESTEP) "    ... memh explicit ok"
@@ -132,8 +134,11 @@ check_args_specific_tsim: sx = $(shell printf 0x%08x $(s))
 check_args_specific_tsim: check_args_specific_%: %$(EXE_SUFFIX)
 	@$(MAKESTEP) "Checking $* specific options ... "
 	$($*) -@ does_not_exist 2>&1 | fgrep -q "No such"            && $(MAKESTEP) "    ... -@ ok"
+	$($*) -ftext -a 123 - <<<0 2>&1 | fgrep -q "address 0x7b"    && $(MAKESTEP) "    ... -a ok"
 	$($*) -d -ftext /dev/null 2>&1 | fgrep -q "executed: 1"      && $(MAKESTEP) "    ... -d ok"
 	(! $($*) -f does_not_exist /dev/null &> /dev/null )          && $(MAKESTEP) "    ... -f ok"
+	(! $($*) -r does_not_exist -ftext /dev/null &> /dev/null )   && $(MAKESTEP) "    ... -r ok"
+	$($*) -ftext -vs $(s) /dev/null 2>&1 | fgrep -q "IP = $(sx)" && $(MAKESTEP) "    ... -s ok"
 	$($*) -ftext -v       /dev/null 2>&1 | fgrep -q "IP ="       && $(MAKESTEP) "    ... -v ok"
 	$($*) -ftext -vv      /dev/null 2>&1 | fgrep -q ".word"      && $(MAKESTEP) "    ... -vv ok"
 	$($*) -ftext -vvv     /dev/null 2>&1 | fgrep -q "read  @"    && $(MAKESTEP) "    ... -vvv ok"

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -117,9 +117,7 @@ check_args_specific_%: %$(EXE_SUFFIX) ;
 
 check_args_specific_tas: check_args_specific_%: %$(EXE_SUFFIX)
 	@$(MAKESTEP) "Checking $* specific options ... "
-	echo -n 9876 | $($*) -fraw -d - | fgrep -q ".word 0x3637"    && $(MAKESTEP) "    ... -d ok"
 	(! $($*) -f does_not_exist /dev/null &> /dev/null )          && $(MAKESTEP) "    ... -f ok"
-	echo -n 9876 | $($*) -fraw -d -q - | fgrep -qv "word 0x3637" && $(MAKESTEP) "    ... -q ok"
 	$($*) -d -ftext -v - <<<0xc | fgrep -q "A + 0x0000000c"      && $(MAKESTEP) "    ... -v ok"
 	echo '.zero 2' | $($*) -fmemh -pformat.memh.explicit=1 - | fgrep -q "@0 00000000" \
 	                                                             && $(MAKESTEP) "    ... memh explicit ok"
@@ -134,11 +132,8 @@ check_args_specific_tsim: sx = $(shell printf 0x%08x $(s))
 check_args_specific_tsim: check_args_specific_%: %$(EXE_SUFFIX)
 	@$(MAKESTEP) "Checking $* specific options ... "
 	$($*) -@ does_not_exist 2>&1 | fgrep -q "No such"            && $(MAKESTEP) "    ... -@ ok"
-	$($*) -fraw -a 123 /dev/zero 2>&1 | fgrep -q "address 0x7b"  && $(MAKESTEP) "    ... -a ok"
 	$($*) -d -ftext /dev/null 2>&1 | fgrep -q "executed: 1"      && $(MAKESTEP) "    ... -d ok"
 	(! $($*) -f does_not_exist /dev/null &> /dev/null )          && $(MAKESTEP) "    ... -f ok"
-	(! $($*) -r does_not_exist -fraw /dev/null &> /dev/null )    && $(MAKESTEP) "    ... -r ok"
-	$($*) -fraw  -vs $(s) /dev/null 2>&1 | fgrep -q "IP = $(sx)" && $(MAKESTEP) "    ... -s ok"
 	$($*) -ftext -v       /dev/null 2>&1 | fgrep -q "IP ="       && $(MAKESTEP) "    ... -v ok"
 	$($*) -ftext -vv      /dev/null 2>&1 | fgrep -q ".word"      && $(MAKESTEP) "    ... -vv ok"
 	$($*) -ftext -vvv     /dev/null 2>&1 | fgrep -q "read  @"    && $(MAKESTEP) "    ... -vvv ok"

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -61,7 +61,7 @@ function match ()
 
 # TODO support obj when identical objects can be made reliably
 for flags in -v "" ; do
-    for fmt in memh raw text ; do
+    for fmt in memh text ; do
         for file in $* ; do
             trap "rm $base.$fmt.{en,de}.[0123]" EXIT
             if [[ $file = *.cpp ]] ; then

--- a/src/asm.c
+++ b/src/asm.c
@@ -436,13 +436,6 @@ static int obj_err(void *ud)
  * Raw format : raw binary data (host endian)
  */
 
-static int raw_init(FILE *stream, struct param_state *p, void **ud)
-{
-    int rc = gen_init(stream, p, ud);
-    os_set_binmode(stream);
-    return rc;
-}
-
 static int raw_in(FILE *stream, struct element *i, void *ud)
 {
     int *offset = ud;
@@ -604,7 +597,7 @@ const struct format tenyr_asm_formats[] = {
         .reloc = obj_reloc,
         .err   = obj_err },
     { "raw",
-        .init  = raw_init ,
+        .init  = gen_init ,
         .in    = raw_in ,
         .out   = raw_out ,
         .fini  = gen_fini },

--- a/src/os/Win32/os_common.h
+++ b/src/os/Win32/os_common.h
@@ -12,11 +12,6 @@
  */
 typedef unsigned int lfind_size_t;
 
-static inline int os_set_binmode(FILE *stream)
-{
-    return setmode(fileno(stream), O_BINARY) == -1;
-}
-
 // timeradd doesn't exist on MinGW
 #ifndef timeradd
 #define timeradd(a, b, result) \

--- a/src/os/default/os_common.h
+++ b/src/os/default/os_common.h
@@ -6,13 +6,6 @@
 
 typedef size_t lfind_size_t;
 
-static inline int os_set_binmode(void *stream)
-{
-    /* no-op */
-    (void)stream;
-    return 0;
-}
-
 char *os_find_self(const char *);
 FILE *os_fopen(const char *, const char *);
 int os_get_tsimrc_path(char buf[], size_t sz);


### PR DESCRIPTION
Since non-text files are already opened with "b" set in the `fopen` flags, I thought that `os_set_binmode`, which is only meaningful on Windows builds, might be able to be removed to ease some concurrent work I am doing (but I was wrong). Now I will remove the `raw` format, since it is non-portable anyway.