### PR TITLE
Create C workflow for GHA

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,0 +1,19 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build in parallel
+      run: make -j
+    - name: Run software-only tests
+      run: make check_sw


### PR DESCRIPTION
Although we have Travis set up already, we might be able to get a native Windows build with GHA, instead of a MinGW one.