### PR TITLE
Implement stream ops layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ clean_FILES = $(addprefix $(BUILDDIR)/,  \
                    random random.*       \
                )#
 
-common_OBJECTS = common.o param.o $(patsubst %.c,%.o,$(notdir $(wildcard $(OS_PATHS:%=%/*.c))))
+common_OBJECTS = common.o param.o $(patsubst %.c,%.o,$(notdir $(wildcard $(OS_PATHS:%=%/*.c)))) \
+                 stream.o
 shared_OBJECTS = common.o
 tas_OBJECTS    = $(common_OBJECTS) asmif.o asm.o obj.o parser.o lexer.o
 tsim_OBJECTS   = $(common_OBJECTS) simif.o asm.o obj.o plugin.o \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(TOP)/build/share/tenyr/%:
 
 .PHONY: vpi
 vpi: vpidevices.vpi
-vpidevices.vpi: callbacks,dy.o vpiserial,dy.o load,dy.o sim,dy.o asm,dy.o obj,dy.o common,dy.o param,dy.o
+vpidevices.vpi: callbacks,dy.o vpiserial,dy.o load,dy.o sim,dy.o asm,dy.o obj,dy.o common,dy.o param,dy.o stream,dy.o
 
 tas$(EXE_SUFFIX):  tas.o  $(tas_OBJECTS)
 tsim$(EXE_SUFFIX): tsim.o $(tsim_OBJECTS)

--- a/hw/vpi/load.c
+++ b/hw/vpi/load.c
@@ -1,4 +1,5 @@
 #include "sim.h"
+#include "stream.h"
 
 #include <vpi_user.h>
 
@@ -66,9 +67,11 @@ int tenyr_sim_load(struct tenyr_sim_state *state)
 
     vpi_free_object(args_iter);
 
-    FILE *stream = fopen(filename, "rb");
-    if (!stream)
+    FILE *file = fopen(filename, "rb");
+    if (!file)
         return 1;
+
+    STREAM stream_ = stream_make_from_file(file), *stream = &stream_;
 
     void *ud = NULL;
     const struct format *f = &tenyr_asm_formats[0];

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -143,7 +143,6 @@ check_args_specific_tsim: check_args_specific_%: %$(EXE_SUFFIX)
 	$($*) -ftext -vv      /dev/null 2>&1 | fgrep -q ".word"      && $(MAKESTEP) "    ... -vv ok"
 	$($*) -ftext -vvv     /dev/null 2>&1 | fgrep -q "read  @"    && $(MAKESTEP) "    ... -vvv ok"
 	$($*) -ftext -vvvv    /dev/null 2>&1 | fgrep -q "P 00001"    && $(MAKESTEP) "    ... -vvvv ok"
-	$($*) -ftext bad0 bad1 2>&1 | fgrep -qi "more than one"      && $(MAKESTEP) "    ... multiple files rejected ok"
 	$($*) -d -ftext - < /dev/null 2>&1 | fgrep -q "executed: 1"  && $(MAKESTEP) "    ... stdin accepted for input ok"
 	$(if $(findstring emscripten,$(PLATFORM)),,(! $($*) -remscript - &> /dev/null )  && $(MAKESTEP) "    ... emscripten recipe rejected ok")
 

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -119,7 +119,7 @@ check_args_specific_tas: check_args_specific_%: %$(EXE_SUFFIX)
 	@$(MAKESTEP) "Checking $* specific options ... "
 	echo 0x3637 | $($*) -ftext -d - | grep -q ".word 0x0*3637"   && $(MAKESTEP) "    ... -d ok"
 	(! $($*) -f does_not_exist /dev/null &> /dev/null )          && $(MAKESTEP) "    ... -f ok"
-	echo 0x3637 | $($*) -ftext -d -q - | fgrep -qv "word 0x3637" && $(MAKESTEP) "    ... -q ok"
+	echo 0x3637 | $($*) -ftext -d -q - | fgrep -qv "3637"        && $(MAKESTEP) "    ... -q ok"
 	$($*) -d -ftext -v - <<<0xc | fgrep -q "A + 0x0000000c"      && $(MAKESTEP) "    ... -v ok"
 	echo '.zero 2' | $($*) -fmemh -pformat.memh.explicit=1 - | fgrep -q "@0 00000000" \
 	                                                             && $(MAKESTEP) "    ... memh explicit ok"

--- a/src/asm.c
+++ b/src/asm.c
@@ -462,7 +462,7 @@ static int text_out(FILE *stream, struct element *i, void *ud)
     if (i->insn.size > 0)
         ok &= fprintf(stream, "0x%08x\n", i->insn.u.word) > 0;
     for (int c = 1; c < i->insn.size && ok; c++)
-        ok &= fputs("0x00000000\n", stream) > 0;
+        ok &= fprintf(stream, "0x00000000\n") > 0;
     return ok ? 1 : -1;
 }
 

--- a/src/asm.c
+++ b/src/asm.c
@@ -216,13 +216,13 @@ int print_registers(FILE *out, const int32_t regs[16])
     for (int i = 0; i < 15; i++) {
         fprintf(out, "%c %08x ", 'A' + i, regs[i]);
         if (i % 6 == 5)
-            fputc('\n', out);
+            fwrite("\n", 1, 1, out);
     }
 
     // Treat P specially : a read would return IP + 1
     fprintf(out, "%c %08x ", 'A' + 15, regs[15] + 1);
 
-    fputc('\n', out);
+    fwrite("\n", 1, 1, out);
 
     return 0;
 }

--- a/src/asm.c
+++ b/src/asm.c
@@ -435,13 +435,6 @@ static int obj_err(void *ud)
 /*******************************************************************************
  * Text format : hexadecimal numbers
  */
-static int text_init(FILE *stream, struct param_state *p, void **ud)
-{
-    // This output might be consumed by a tool that needs a line at a time
-    return gen_init(stream, p, ud)
-        || os_set_buffering(stream, _IOLBF);
-}
-
 static int text_in(FILE *stream, struct element *i, void *ud)
 {
     int32_t *offset = ud;
@@ -559,7 +552,7 @@ const struct format tenyr_asm_formats[] = {
         .reloc = obj_reloc,
         .err   = obj_err },
     { "text",
-        .init  = text_init,
+        .init  = gen_init,
         .in    = text_in,
         .out   = text_out,
         .fini  = gen_fini },

--- a/src/asm.h
+++ b/src/asm.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "param.h"
+#include "stream.h"
 
 struct element;
 struct symbol;
@@ -12,16 +13,16 @@ struct reloc_node;
 
 struct format {
     const char *name;
-    int (*init )(FILE *, struct param_state *, void **ud);
-    int (*in   )(FILE *, struct element *, void *ud);
-    int (*out  )(FILE *, struct element *, void *ud);
+    int (*init )(STREAM *, struct param_state *, void **ud);
+    int (*in   )(STREAM *, struct element *, void *ud);
+    int (*out  )(STREAM *, struct element *, void *ud);
 
-    int (*sym  )(FILE *, struct symbol *, int, void *ud);
-    int (*reloc)(FILE *, struct reloc_node *, void *ud);
+    int (*sym  )(STREAM *, struct symbol *, int, void *ud);
+    int (*reloc)(STREAM *, struct reloc_node *, void *ud);
 
-    int (*emit )(FILE *, void **ud);
-    int (*fini )(FILE *, void **ud);
-    int (*err  )(        void  *ud);
+    int (*emit )(STREAM *, void **ud);
+    int (*fini )(STREAM *, void **ud);
+    int (*err  )(          void  *ud);
 };
 
 #define ASM_AS_INSN                 (1 << 0)
@@ -33,8 +34,8 @@ struct format {
 #define ASM_FORCE_DECIMAL_CONSTANTS (1 << 6)
 
 // returns number of characters printed
-int print_disassembly(FILE *out, const struct element *i, int flags);
-int print_registers(FILE *out, const int32_t regs[16]);
+int print_disassembly(STREAM *out, const struct element *i, int flags);
+int print_registers(STREAM *out, const int32_t regs[16]);
 
 extern const struct format tenyr_asm_formats[];
 extern const size_t tenyr_asm_formats_count;

--- a/src/asmif.c
+++ b/src/asmif.c
@@ -346,7 +346,7 @@ static int assembly_fixup_insns(struct parse_data *pd)
     return 0;
 }
 
-static int assembly_inner(struct parse_data *pd, FILE *out, const struct format *f, void *ud)
+static int assembly_inner(struct parse_data *pd, STREAM *out, const struct format *f, void *ud)
 {
     assembly_fixup_insns(pd);
 
@@ -380,7 +380,7 @@ static int assembly_inner(struct parse_data *pd, FILE *out, const struct format 
     return 0;
 }
 
-int do_assembly(FILE *in, FILE *out, const struct format *f, void *ud)
+int do_assembly(STREAM *in, STREAM *out, const struct format *f, void *ud)
 {
     struct parse_data _pd = {
         .top = NULL,
@@ -388,7 +388,7 @@ int do_assembly(FILE *in, FILE *out, const struct format *f, void *ud)
 
     tenyr_lex_init(&pd->scanner);
     tenyr_set_extra(pd, pd->scanner);
-    tenyr_set_in(in, pd->scanner);
+    tenyr_set_in(in->ud, pd->scanner);
 
     int result = tenyr_parse(pd);
     if (pd->errored)
@@ -401,27 +401,27 @@ int do_assembly(FILE *in, FILE *out, const struct format *f, void *ud)
     return result || pd->errored;
 }
 
-int do_disassembly(FILE *in, FILE *out, const struct format *f, void *ud, int flags)
+int do_disassembly(STREAM *in, STREAM *out, const struct format *f, void *ud, int flags)
 {
     int rc = 0;
 
     struct element i;
     while ((rc = f->in(in, &i, ud)) >= 0) {
-        if (feof(in))
+        if (in->op.feof(in))
             break;
         if (rc == 0)
             continue; // allow a format to emit no instructions
         int len = print_disassembly(out, &i, ASM_AS_INSN | flags);
         if (!(flags & ASM_QUIET)) {
-            fprintf(out, "%*s# ", 30 - len, "");
+            out->op.fprintf(out, "%*s# ", 30 - len, "");
             print_disassembly(out, &i, ASM_AS_DATA | flags);
-            fprintf(out, " ; ");
+            out->op.fprintf(out, " ; ");
             print_disassembly(out, &i, ASM_AS_CHAR | flags);
-            fprintf(out, " ; .addr 0x%08x\n", i.insn.reladdr);
+            out->op.fprintf(out, " ; .addr 0x%08x\n", i.insn.reladdr);
         } else {
-            fwrite("\n", 1, 1, out);
+            out->op.fwrite("\n", 1, 1, out);
             // This probably means we want line-oriented output
-            fflush(out);
+            out->op.fflush(out);
         }
     }
 

--- a/src/asmif.c
+++ b/src/asmif.c
@@ -419,7 +419,7 @@ int do_disassembly(FILE *in, FILE *out, const struct format *f, void *ud, int fl
             print_disassembly(out, &i, ASM_AS_CHAR | flags);
             fprintf(out, " ; .addr 0x%08x\n", i.insn.reladdr);
         } else {
-            fputc('\n', out);
+            fwrite("\n", 1, 1, out);
             // This probably means we want line-oriented output
             fflush(out);
         }

--- a/src/asmif.h
+++ b/src/asmif.h
@@ -1,12 +1,14 @@
 #ifndef ASMIF_H_
 #define ASMIF_H_
 
+#include "stream.h"
+
 #include <stdio.h>
 
 struct format;
 
-int do_assembly(FILE *in, FILE *out, const struct format *f, void *ud);
-int do_disassembly(FILE *in, FILE *out, const struct format *f, void *ud, int flags);
+int do_assembly(STREAM *in, STREAM *out, const struct format *f, void *ud);
+int do_disassembly(STREAM *in, STREAM *out, const struct format *f, void *ud, int flags);
 
 #endif
 

--- a/src/common.c
+++ b/src/common.c
@@ -36,7 +36,7 @@ static void NORETURN main_fatal_(int code, const char *file, int line,
     if (code & PRINT_ERRNO)
         fprintf(stderr, ": %s\n", strerror(errno));
     else
-        fputc('\n', stderr);
+        fwrite("\n", 1, 1, stderr);
 
     longjmp(errbuf, code);
 }

--- a/src/devices/serial.c
+++ b/src/devices/serial.c
@@ -54,7 +54,7 @@ static int serial_op(void *cookie, int op, uint32_t addr, uint32_t *data)
     int rc = -1;
 
     if (op == OP_WRITE) {
-        fputc(*data, s->out);
+        fwrite(data, 1, 1, s->out);
         fflush(s->out);
         rc = ferror(s->out);
     } else if (op == OP_DATA_READ) {

--- a/src/obj.h
+++ b/src/obj.h
@@ -2,6 +2,7 @@
 #define OBJ_H_
 
 #include "common.h"
+#include "stream.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -71,8 +72,8 @@ struct obj {
     } *relocs;
 };
 
-int obj_write(struct obj *o, FILE *out);
-int obj_read(struct obj *o, FILE *in);
+int obj_write(struct obj *o, STREAM *out);
+int obj_read(struct obj *o, STREAM *in);
 void obj_free(struct obj *o);
 
 static inline size_t round_up_to_word(size_t x)

--- a/src/parser.y
+++ b/src/parser.y
@@ -410,8 +410,8 @@ int tenyr_error(YYLTYPE *locp, struct parse_data *pd, const char *fmt, ...)
         fprintf(stderr, "%*s", col, "^");
         int len = locp->last_column - locp->first_column;
         while (len-- > 0)
-            fputc('^', stderr);
-        fputc('\n', stderr);
+            fwrite("^", 1, 1, stderr);
+        fwrite("\n", 1, 1, stderr);
     }
 
     va_start(vl, fmt);
@@ -421,7 +421,7 @@ int tenyr_error(YYLTYPE *locp, struct parse_data *pd, const char *fmt, ...)
     fprintf(stderr, " at line %d", locp->first_line);
     if (locp->first_column >= 0)
         fprintf(stderr, " column %d at `%s'", col, tenyr_get_text(pd->scanner));
-    fputc('\n', stderr);
+    fwrite("\n", 1, 1, stderr);
 
     pd->errored++;
     return 0;

--- a/src/sim.c
+++ b/src/sim.c
@@ -172,7 +172,7 @@ int interp_run_sim(struct sim_state *s, const struct run_ops *ops,
 }
 
 int load_sim(op_dispatcher *dispatch, void *sud, const struct format *f,
-        void *ud, FILE *in, int load_address)
+        void *ud, STREAM *in, int load_address)
 {
     struct element i;
     while (f->in(in, &i, ud) >= 0) {

--- a/src/sim.h
+++ b/src/sim.h
@@ -77,7 +77,7 @@ struct run_ops {
 
 extern sim_runner interp_run_sim, interp_step_sim;
 int load_sim(op_dispatcher *dispatch_op, void *sud, const struct format *f,
-        void *fud, FILE *in, int load_address);
+        void *fud, STREAM *in, int load_address);
 
 #define breakpoint(...) \
     fatal(0, __VA_ARGS__)

--- a/src/stream.c
+++ b/src/stream.c
@@ -90,3 +90,11 @@ struct stream_ops stream_get_default_ops(void)
     };
 }
 
+struct stream stream_make_from_file(FILE *f)
+{
+	return (struct stream){
+        .ud = f,
+        .op = stream_get_default_ops(),
+    };
+}
+

--- a/src/stream.c
+++ b/src/stream.c
@@ -25,7 +25,7 @@ static int default_printf(STREAM *s, const char *format, ...)
     return wrote == (size_t)need ? need : -1;
 }
 
-static int default_scanf(STREAM *s, const char *format, ...)
+static int default_scanf(STREAM *s, const char *format, unsigned int *word)
 {
     // It is not feasible to defer to op.fread here. We might try to keep a
     // buffer of our own to read "enough" to satisfy a vsscanf call, but we
@@ -34,17 +34,13 @@ static int default_scanf(STREAM *s, const char *format, ...)
     // int to the va_list -- and there is no portable way to append to a
     // va_list.
     //
-    // Instead, we simply defer to the system vfscanf. If a library user wants
+    // Instead, we simply defer to the system fscanf. If a library user wants
     // to read the text-based formats (which are the only ones that want
     // fscanf), it could, at worst, convert them to raw format first, perhaps
     // by using `tas -d -ftext - | tas -fraw -`. Since the text formats are
     // meant basically for demonstration and are of increasingly limited use,
     // this is not perceived to be a great limitation.
-    va_list vl;
-    va_start(vl, format);
-    int result = vfscanf(s->ud, format, vl);
-    va_end(vl);
-    return result;
+    return fscanf(s->ud, format, word);
 }
 
 static size_t default_read(void *ptr, size_t size, size_t nitems, STREAM *s)

--- a/src/stream.c
+++ b/src/stream.c
@@ -25,7 +25,7 @@ static int default_printf(STREAM *s, const char *format, ...)
     return wrote == (size_t)need ? need : -1;
 }
 
-int default_scanf(STREAM *s, const char *format, ...)
+static int default_scanf(STREAM *s, const char *format, ...)
 {
     // It is not feasible to defer to op.fread here. We might try to keep a
     // buffer of our own to read "enough" to satisfy a vsscanf call, but we
@@ -67,12 +67,12 @@ static int default_flush(STREAM *s)
     return fflush(s->ud);
 }
 
-int default_seek(STREAM *s, long offset, int whence)
+static int default_seek(STREAM *s, long offset, int whence)
 {
     return fseek(s->ud, offset, whence);
 }
 
-long default_tell(STREAM *s)
+static long default_tell(STREAM *s)
 {
     return ftell(s->ud);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -21,7 +21,8 @@ static int default_printf(STREAM *s, const char *format, ...)
     if (need > 0 && (size_t)need >= sizeof buf)
         return -1; // we ran out of space
 
-    return s->op.fwrite(buf, need, 1, s);
+    size_t wrote = s->op.fwrite(buf, (size_t)need, 1, s);
+    return wrote == (size_t)need ? need : -1;
 }
 
 int default_scanf(STREAM *s, const char *format, ...)

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,0 +1,92 @@
+#include "stream.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+static int default_printf(STREAM *s, const char *format, ...)
+{
+    // We do not try to be completely general -- if the formatted string will
+    // not fit in a BUFSIZ, we reserve the right to consider that an error.
+    // Failing this way is safer than using a variable-length-array and faster
+    // than allocating from the free store, which means it is better for our
+    // purposes.
+    char buf[BUFSIZ];
+
+    va_list vl;
+    va_start(vl, format);
+
+    int need = vsnprintf(buf, sizeof buf, format, vl);
+    va_end(vl);
+
+    if (need > 0 && (size_t)need >= sizeof buf)
+        return -1; // we ran out of space
+
+    return s->op.fwrite(buf, need, 1, s);
+}
+
+int default_scanf(STREAM *s, const char *format, ...)
+{
+    // It is not feasible to defer to op.fread here. We might try to keep a
+    // buffer of our own to read "enough" to satisfy a vsscanf call, but we
+    // would not know how many bytes of that buffer were successfully consumed
+    // unless we could append an "n" specifier to the format and a pointer to
+    // int to the va_list -- and there is no portable way to append to a
+    // va_list.
+    //
+    // Instead, we simply defer to the system vfscanf. If a library user wants
+    // to read the text-based formats (which are the only ones that want
+    // fscanf), it could, at worst, convert them to raw format first, perhaps
+    // by using `tas -d -ftext - | tas -fraw -`. Since the text formats are
+    // meant basically for demonstration and are of increasingly limited use,
+    // this is not perceived to be a great limitation.
+    va_list vl;
+    va_start(vl, format);
+    int result = vfscanf(s->ud, format, vl);
+    va_end(vl);
+    return result;
+}
+
+static size_t default_read(void *ptr, size_t size, size_t nitems, STREAM *s)
+{
+    return fread(ptr, size, nitems, s->ud);
+}
+
+static size_t default_write(const void *ptr, size_t size, size_t nitems, STREAM *s)
+{
+    return fwrite(ptr, size, nitems, s->ud);
+}
+
+static int default_eof(STREAM *s)
+{
+    return feof(s->ud);
+}
+
+static int default_flush(STREAM *s)
+{
+    return fflush(s->ud);
+}
+
+int default_seek(STREAM *s, long offset, int whence)
+{
+    return fseek(s->ud, offset, whence);
+}
+
+long default_tell(STREAM *s)
+{
+    return ftell(s->ud);
+}
+
+struct stream_ops stream_get_default_ops(void)
+{
+    return (struct stream_ops){
+        .fprintf = default_printf,
+        .fscanf = default_scanf,
+        .fread = default_read,
+        .fwrite = default_write,
+        .feof = default_eof,
+        .fflush = default_flush,
+        .fseek = default_seek,
+        .ftell = default_tell,
+    };
+}
+

--- a/src/stream.h
+++ b/src/stream.h
@@ -8,24 +8,30 @@
 
 typedef struct stream STREAM;
 
-typedef int stream_printf(STREAM *s, const char *format, ...);
-typedef int stream_scanf(STREAM *s, const char *format, ...);
-typedef size_t stream_read(void *ptr, size_t size, size_t nitems, STREAM *s);
-typedef size_t stream_write(const void *ptr, size_t size, size_t nitems, STREAM *s);
-typedef int stream_eof(STREAM *s);
-typedef int stream_flush(STREAM *s);
-typedef int stream_seek(STREAM *s, long offset, int whence);
-typedef long stream_tell(STREAM *s);
+typedef int    stream_printf (STREAM *s, const char *format, ...);
+typedef int    stream_scanf  (STREAM *s, const char *format, ...);
+
+typedef size_t stream_read   (      void *ptr, size_t size, size_t nitems, STREAM *s);
+typedef size_t stream_write  (const void *ptr, size_t size, size_t nitems, STREAM *s);
+
+typedef int    stream_eof    (STREAM *s);
+typedef int    stream_flush  (STREAM *s);
+
+typedef int    stream_seek   (STREAM *s, long offset, int whence);
+typedef long   stream_tell   (STREAM *s);
 
 struct stream_ops {
     stream_printf *fprintf;
-    stream_scanf *fscanf;
-    stream_read *fread;
-    stream_write *fwrite;
-    stream_eof *feof;
-    stream_flush *fflush;
-    stream_seek *fseek;
-    stream_tell *ftell;
+    stream_scanf  *fscanf;
+
+    stream_read   *fread;
+    stream_write  *fwrite;
+
+    stream_eof    *feof;
+    stream_flush  *fflush;
+
+    stream_seek   *fseek;
+    stream_tell   *ftell;
 };
 
 struct stream {

--- a/src/stream.h
+++ b/src/stream.h
@@ -1,3 +1,6 @@
+// Provides a thin abstraction over C streams (FILE*) in order to enable
+// library interactions with software that does not support FILE* (e.g. FFI
+// with non-C languages).
 #ifndef STREAM_H_
 #define STREAM_H_
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -3,14 +3,26 @@
 
 #include <stddef.h>
 
-typedef int stream_printf(void *userdata, const char *format, ...);
-typedef size_t stream_read(void *ptr, size_t size, size_t nitems, void *userdata);
-typedef size_t stream_write(const void *ptr, size_t size, size_t nitems, void *userdata);
+typedef struct stream STREAM;
+
+typedef int stream_printf(STREAM *s, const char *format, ...);
+typedef int stream_scanf(STREAM *s, const char *format, ...);
+typedef size_t stream_read(void *ptr, size_t size, size_t nitems, STREAM *s);
+typedef size_t stream_write(const void *ptr, size_t size, size_t nitems, STREAM *s);
+typedef int stream_eof(STREAM *s);
+typedef int stream_flush(STREAM *s);
+typedef int stream_seek(STREAM *s, long offset, int whence);
+typedef long stream_tell(STREAM *s);
 
 struct stream_ops {
     stream_printf *fprintf;
+    stream_scanf *fscanf;
     stream_read *fread;
     stream_write *fwrite;
+    stream_eof *feof;
+    stream_flush *fflush;
+    stream_seek *fseek;
+    stream_tell *ftell;
 };
 
 struct stream {
@@ -18,7 +30,7 @@ struct stream {
     const struct stream_ops op;
 };
 
-typedef struct stream STREAM;
+struct stream_ops stream_get_default_ops(void);
 
 #endif
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -10,7 +10,12 @@
 typedef const struct stream STREAM;
 
 typedef int    stream_printf (STREAM *s, const char *format, ...);
-typedef int    stream_scanf  (STREAM *s, const char *format, ...);
+// stream_scanf previously supported variable parameter lists, like normal
+// scanf. Unfortunately, this ran into memory errors with the MinGW build under
+// Wine. Since we currently only ever need to scan one item of a fixed type,
+// after some other characters, we constrain the interface to avoid using
+// stdarg.
+typedef int    stream_scanf  (STREAM *s, const char *format, unsigned int *out);
 
 typedef size_t stream_read   (      void *ptr, size_t size, size_t nitems, STREAM *s);
 typedef size_t stream_write  (const void *ptr, size_t size, size_t nitems, STREAM *s);

--- a/src/stream.h
+++ b/src/stream.h
@@ -1,0 +1,25 @@
+#ifndef STREAM_H_
+#define STREAM_H_
+
+#include <stddef.h>
+
+typedef int stream_printf(void *userdata, const char *format, ...);
+typedef size_t stream_read(void *ptr, size_t size, size_t nitems, void *userdata);
+typedef size_t stream_write(const void *ptr, size_t size, size_t nitems, void *userdata);
+
+struct stream_ops {
+    stream_printf *fprintf;
+    stream_read *fread;
+    stream_write *fwrite;
+};
+
+struct stream {
+    void *ud; ///< userdata
+    const struct stream_ops op;
+};
+
+typedef struct stream STREAM;
+
+#endif
+
+/* vi: set ts=4 sw=4 et: */

--- a/src/stream.h
+++ b/src/stream.h
@@ -5,6 +5,7 @@
 #define STREAM_H_
 
 #include <stddef.h>
+#include <stdio.h>
 
 typedef struct stream STREAM;
 
@@ -40,6 +41,8 @@ struct stream {
 };
 
 struct stream_ops stream_get_default_ops(void);
+
+struct stream stream_make_from_file(FILE *f);
 
 #endif
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-typedef struct stream STREAM;
+typedef const struct stream STREAM;
 
 typedef int    stream_printf (STREAM *s, const char *format, ...);
 typedef int    stream_scanf  (STREAM *s, const char *format, ...);

--- a/src/tas.c
+++ b/src/tas.c
@@ -67,15 +67,8 @@ static int process_stream(struct param_state *params, const struct format *f,
 {
     int rc = 0;
 
-    struct stream in_ = {
-        .op = stream_get_default_ops(),
-        .ud = infile,
-    }, *in = &in_;
-
-    struct stream out_ = {
-        .op = stream_get_default_ops(),
-        .ud = outfile,
-    }, *out = &out_;
+    const struct stream in_ = stream_make_from_file(infile), *in = &in_;
+    const struct stream out_ = stream_make_from_file(outfile), *out = &out_;
 
     int disassemble = flags & ASM_DISASSEMBLE;
     STREAM *stream = disassemble ? in : out;

--- a/src/tld.c
+++ b/src/tld.c
@@ -328,10 +328,7 @@ int do_load_all(struct link_state *s, int count, char *names[count])
         // (emscripten)
         clearerr(infile);
 
-        struct stream in_ = {
-            .op = stream_get_default_ops(),
-            .ud = infile,
-        }, *in = &in_;
+        const struct stream in_ = stream_make_from_file(infile), *in = &in_;
 
         rc = do_load(s, in);
         int saved = errno;
@@ -408,10 +405,7 @@ int main(int argc, char *argv[])
     if (!outfile)
         fatal(PRINT_ERRNO, "Failed to open output file `%s'", outfname ? outfname : "<stdout>");
 
-    struct stream out_ = {
-        .op = stream_get_default_ops(),
-        .ud = outfile,
-    }, *out = &out_;
+    const struct stream out_ = stream_make_from_file(outfile), *out = &out_;
 
     rc = do_load_all(s, argc - optind, &argv[optind]);
     if (rc)

--- a/src/tld.c
+++ b/src/tld.c
@@ -76,7 +76,7 @@ static int usage(const char *me)
     return 0;
 }
 
-static int do_load(struct link_state *s, FILE *in)
+static int do_load(struct link_state *s, STREAM *in)
 {
     int rc = 0;
     struct obj_list *node = calloc(1, sizeof *node);
@@ -300,7 +300,7 @@ static int do_link(struct link_state *s)
     return rc;
 }
 
-static int do_emit(struct link_state *s, FILE *out)
+static int do_emit(struct link_state *s, STREAM *out)
 {
     int rc = -1;
 
@@ -314,24 +314,29 @@ int do_load_all(struct link_state *s, int count, char *names[count])
     int rc = 0;
 
     for (int i = 0; i < count; i++) {
-        FILE *in = NULL;
+        FILE *infile = NULL;
 
         if (!strcmp(names[i], "-")) {
-            in = stdin;
+            infile = stdin;
         } else {
-            in = os_fopen(names[i], "rb");
-            if (!in)
+            infile = os_fopen(names[i], "rb");
+            if (!infile)
                 fatal(PRINT_ERRNO, "Failed to open input file `%s'", names[i]);
         }
 
         // Explicitly clear errors and EOF in case we run main() twice
         // (emscripten)
-        clearerr(in);
+        clearerr(infile);
+
+        struct stream in_ = {
+            .op = stream_get_default_ops(),
+            .ud = infile,
+        }, *in = &in_;
 
         rc = do_load(s, in);
         int saved = errno;
 
-        fclose(in);
+        fclose(infile);
 
         errno = saved;
         if (rc)
@@ -351,7 +356,7 @@ int main(int argc, char *argv[])
     }, *s = &_s;
 
     char * volatile outfname = NULL;
-    FILE * volatile out = stdout;
+    FILE * volatile outfile = stdout;
 
     struct param_state * volatile params = NULL;
     param_init((struct param_state **)&params);
@@ -359,7 +364,7 @@ int main(int argc, char *argv[])
     if ((rc = setjmp(errbuf))) {
         if (rc == DISPLAY_USAGE)
             usage(argv[0]);
-        if (out != stdout && outfname != NULL)
+        if (outfile != stdout && outfname != NULL)
             // Technically there is a race condition here ; we would like to be
             // able to remove a file by a stream connected to it, but there is
             // apparently no portable way to do this.
@@ -399,9 +404,14 @@ int main(int argc, char *argv[])
     os_preamble();
 
     if (outfname)
-        out = os_fopen(outfname, "wb");
-    if (!out)
+        outfile = os_fopen(outfname, "wb");
+    if (!outfile)
         fatal(PRINT_ERRNO, "Failed to open output file `%s'", outfname ? outfname : "<stdout>");
+
+    struct stream out_ = {
+        .op = stream_get_default_ops(),
+        .ud = outfile,
+    }, *out = &out_;
 
     rc = do_load_all(s, argc - optind, &argv[optind]);
     if (rc)
@@ -415,7 +425,7 @@ int main(int argc, char *argv[])
     }
     free(s->relocated);
 
-    fclose(out);
+    fclose(outfile);
     out = NULL;
 
 cleanup:

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -143,10 +143,7 @@ static int pre_insn(struct sim_state *s, const struct element *i, void *ud)
     if (s->conf.verbose > 0)
         fprintf(stderr, "IP = 0x%08x\t", s->machine.regs[15]);
 
-    struct stream out_ = {
-        .op = stream_get_default_ops(),
-        .ud = stderr,
-    }, *out = &out_;
+    const struct stream out_ = stream_make_from_file(stderr), *out = &out_;
 
     if (s->conf.verbose > 1) {
         int len = print_disassembly(out, i, ASM_AS_INSN);
@@ -519,10 +516,7 @@ int main(int argc, char *argv[])
     // (emscripten)
     clearerr(infile);
 
-    struct stream in_ = {
-        .op = stream_get_default_ops(),
-        .ud = infile,
-    }, *in = &in_;
+    const struct stream in_ = stream_make_from_file(infile), *in = &in_;
 
     devices_setup(s);
     run_recipes(s);

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -149,12 +149,12 @@ static int pre_insn(struct sim_state *s, const struct element *i, void *ud)
     }
 
     if (s->conf.verbose > 3) {
-        fputs("\n", stderr);
+        fwrite("\n", 1, 1, stderr);
         print_registers(stderr, s->machine.regs);
     }
 
     if (s->conf.verbose > 0)
-        fputs("\n", stderr);
+        fwrite("\n", 1, 1, stderr);
 
     return 0;
 }

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -8,6 +8,7 @@
 #include "sim.h"
 // for RAM_BASE
 #include "devices/ram.h"
+#include "stream.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -142,15 +143,20 @@ static int pre_insn(struct sim_state *s, const struct element *i, void *ud)
     if (s->conf.verbose > 0)
         fprintf(stderr, "IP = 0x%08x\t", s->machine.regs[15]);
 
+    struct stream out_ = {
+        .op = stream_get_default_ops(),
+        .ud = stderr,
+    }, *out = &out_;
+
     if (s->conf.verbose > 1) {
-        int len = print_disassembly(stderr, i, ASM_AS_INSN);
+        int len = print_disassembly(out, i, ASM_AS_INSN);
         fprintf(stderr, "%*s# ", 30 - len, "");
-        print_disassembly(stderr, i, ASM_AS_DATA);
+        print_disassembly(out, i, ASM_AS_DATA);
     }
 
     if (s->conf.verbose > 3) {
         fwrite("\n", 1, 1, stderr);
-        print_registers(stderr, s->machine.regs);
+        print_registers(out, s->machine.regs);
     }
 
     if (s->conf.verbose > 0)
@@ -499,19 +505,24 @@ int main(int argc, char *argv[])
         fatal(DISPLAY_USAGE, "More than one input file specified on the command line");
     }
 
-    FILE *in;
+    FILE *infile;
 
     if (!strcmp(argv[optind], "-")) {
-        in = stdin;
+        infile = stdin;
     } else {
-        in = os_fopen(argv[optind], "rb");
-        if (!in)
+        infile = os_fopen(argv[optind], "rb");
+        if (!infile)
             fatal(PRINT_ERRNO, "Failed to open input file `%s'", argv[optind]);
     }
 
     // Explicitly clear errors and EOF in case we run main() twice
     // (emscripten)
-    clearerr(in);
+    clearerr(infile);
+
+    struct stream in_ = {
+        .op = stream_get_default_ops(),
+        .ud = infile,
+    }, *in = &in_;
 
     devices_setup(s);
     run_recipes(s);
@@ -545,7 +556,7 @@ int main(int argc, char *argv[])
     if (rc < 0)
         fprintf(stderr, "Error during simulation, P=0x%08x\n", s->machine.regs[15]);
 
-    fclose(in);
+    fclose(infile);
 
     devices_teardown(s);
 


### PR DESCRIPTION
Possible future use of tenyr code as a library suggests that `FILE*` should not be the main I/O interface. Introduce a thin shim for `FILE*` for now.