### PR TITLE
Set Travis distribution to `bionic` (18.04 LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ matrix:
           packages:
             - libsdl2-dev
             - libsdl2-image-dev
+            - iverilog
     - compiler: "gcc"
       language: c
       os: linux
@@ -136,7 +137,6 @@ sudo: false
 before_script:
   - mkdir -p $DEPSSRC
   - if [[ $JIT != 0 ]] ; then ./scripts/build-lightning.sh 2.1.3 $DEPSSRC ; fi
-  - if [[ $TRAVIS_OS_NAME = linux ]] ; then curl -s 'http://dl.tenyr.info/deps/iverilog-s20140801-139-gaf85d44-x86_64-linux-binaries-0.10.0.tar.gz' | tar -C $DEPSSRC -zx ; fi
   - if [[ $PLATFORM = mingw ]] ; then make download-all-sdl2 ; fi
   - if [[ $PLATFORM = mingw ]] ; then sed "s#{{{}}}#z:$(echo $PWD/3rdparty/sdl2/$HOST-w64-mingw32/bin | sed 's#/#\\\\\\\\#g')#" scripts/winepath.reg > scripts/winepath2.reg ; wine regedit scripts/winepath2.reg ; fi
   - if [[ $TRAVIS_OS_NAME = osx ]] ; then brew install bison ; BISONS=(/usr/local/Cellar/bison/*/bin/bison) ; export BISON="${BISONS[${#BISONS[@]}-1]}" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-x86-64
+            - wine32
             - wine-stable
     - compiler: i686-w64-mingw32-gcc
       language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ matrix:
             - lcov
             - libsdl2-dev
             - libsdl2-image-dev
+            - iverilog
     - compiler: "gcc"
       language: c
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 addons: &def_addons
   artifacts:
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-x86-64
-            - wine32
+            - wine64
             - wine-stable
     - compiler: i686-w64-mingw32-gcc
       language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-x86-64
-            - wine
+            - wine-stable
     - compiler: i686-w64-mingw32-gcc
       language: c
       sudo: required
@@ -45,7 +45,8 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-i686
-            - wine
+            - wine32
+            - wine-stable
     - compiler: "clang"
       language: c
       os: osx

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -13,7 +13,7 @@ $(TOP)rsrc/font10x15/%:
 
 # Do not halt the build for platforms on which the feature-flag _BSD_SOURCE is
 # unused.
-sdl%.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)unused-macros -W'$(PEDANTRY_EXCEPTION)#warnings'
+sdl%.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)unused-macros -W'$(PEDANTRY_EXCEPTION)\#warnings'
 endif
 endif
 

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -13,7 +13,7 @@ $(TOP)rsrc/font10x15/%:
 
 # Do not halt the build for platforms on which the feature-flag _BSD_SOURCE is
 # unused.
-sdl%.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)unused-macros
+sdl%.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)unused-macros -W'$(PEDANTRY_EXCEPTION)#warnings'
 endif
 endif
 


### PR DESCRIPTION
Using `Bionic` will allow the use of Icarus Verilog packages instead of a custom download.