### PR TITLE
Remove references to C++ build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
       os: linux
       env:
         - PLATFORM=mingw BITS=64 HOST=x86_64
-        - CXX=$HOST-w64-mingw32-g++
         - CHECK_RULE=check_sw GCOV=  JIT=0 SDL=0
         - PKG_RULE=zip
       addons:
@@ -30,7 +29,6 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-x86-64
-            - g++-mingw-w64-x86-64
             - wine
     - compiler: i686-w64-mingw32-gcc
       language: c
@@ -38,7 +36,6 @@ matrix:
       os: linux
       env:
         - PLATFORM=mingw BITS=32 HOST=i686
-        - CXX=$HOST-w64-mingw32-g++
         - CHECK_RULE=check_sw GCOV=  JIT=0 SDL=0
         - PKG_RULE=zip
       addons:
@@ -46,7 +43,6 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-i686
-            - g++-mingw-w64-i686
             - wine
     - compiler: "clang"
       language: c
@@ -55,7 +51,6 @@ matrix:
         - PLATFORM=osx   BITS=64 HOST=x86_64
         - CHECK_RULE=check_sw GCOV=       SDL=0
         - PKG_RULE=gzip
-        - CXX=clang++
     - compiler: "gcc"
       language: c
       os: osx
@@ -70,7 +65,6 @@ matrix:
         - PLATFORM=linux BITS=64 HOST=x86_64
         - CHECK_RULE=check_sw GCOV=
         - PKG_RULE=gzip
-        - CXX=clang++
         - SANITIZE=address
         - ASAN_OPTIONS=detect_leaks=0 # TODO enable leak detection by removing this line
       addons:
@@ -86,7 +80,6 @@ matrix:
         - PLATFORM=linux BITS=64 HOST=x86_64
         - CHECK_RULE=check GCOV=
         - PKG_RULE=gzip
-        - CXX=clang++
       addons:
         <<: *def_addons
         apt:

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -15,14 +15,12 @@ export MAKESTEP
 
 ifndef NDEBUG
  CFLAGS   += -g
- CXXFLAGS += -g
  LDFLAGS  += -g
 endif
 
 # Set up -fsanitize= options
 SANITIZE_FLAGS += $(SANITIZE:%=-fsanitize=%)
 CFLAGS   += $(SANITIZE_FLAGS)
-CXXFLAGS += $(SANITIZE_FLAGS)
 LDFLAGS  += $(SANITIZE_FLAGS)
 
 ifeq ($(MEMCHECK),1)
@@ -60,17 +58,14 @@ endif
 ifeq ($(DEBUG),)
  CPPFLAGS += -DNDEBUG
  CFLAGS   += -O3
- CXXFLAGS += -O3
 else
  CPPFLAGS += -DDEBUG=$(DEBUG)
  CFLAGS   += -fstack-protector -Wstack-protector
  CFLAGS   += -O0
- CXXFLAGS += -O0
 endif
 
 CFLAGS += -std=c99
 CFLAGS += -Wall -Wextra -Wshadow $(PEDANTIC_FLAGS)
-CXXFLAGS += -Wall -Wshadow
  #-Wextra $(PEDANTIC_FLAGS)
 ifeq ($(PEDANTIC),)
  PEDANTIC_FLAGS ?= -pedantic
@@ -80,7 +75,6 @@ endif
 
 COVERAGE_FLAGS = $(if $(GCOV),--coverage -O0)
 CFLAGS   += $(COVERAGE_FLAGS)
-CXXFLAGS += $(COVERAGE_FLAGS)
 LDFLAGS  += $(COVERAGE_FLAGS)
 
 CPPFLAGS += $(patsubst %,-D%,$(DEFINES)) \
@@ -124,7 +118,6 @@ include $(TOP)/mk/os/vars/default.mk
 # OS Makefiles might have set CROSS_COMPILE. Since we are using `:=` instead of
 # `=`, order of assignment of variables matters.
 CC  := $(CROSS_COMPILE)$(CC)
-CXX := $(CROSS_COMPILE)$(CXX)
 
 include $(TOP)/mk/sdl.mk
 include $(TOP)/mk/jit.mk

--- a/mk/jit.mk
+++ b/mk/jit.mk
@@ -1,4 +1,3 @@
-libtenyrjit$(DYLIB_SUFFIX): LDFLAGS += $(CXXFLAGS_PIC) -shared
 libtenyrjit$(DYLIB_SUFFIX): LDLIBS += -llightning
 libtenyrjit$(DYLIB_SUFFIX): param,dy.o
 libtenyrjit$(DYLIB_SUFFIX): cjit,dy.o

--- a/mk/os/vars/Win32.mk
+++ b/mk/os/vars/Win32.mk
@@ -5,15 +5,13 @@ PATH_COMPONENT_SEP=\\\\
 PATH_SEP_CHAR = ';'
 EXE_SUFFIX = .exe
 CFLAGS_PIC =
-CXXFLAGS_PIC =
-CXXFLAGS += -fpermissive
 CC := gcc
 ifeq ($(BITS),32)
  CROSS_COMPILE ?= i686-w64-mingw32-
 else
  CROSS_COMPILE ?= x86_64-w64-mingw32-
 endif
-LDFLAGS += -Wl,--kill-at -static-libgcc -static-libstdc++ -static
+LDFLAGS += -Wl,--kill-at -static-libgcc -static
 # JIT on Windows doesn't work yet
 JIT = 0
 

--- a/mk/os/vars/default.mk
+++ b/mk/os/vars/default.mk
@@ -1,6 +1,5 @@
 # this file is included by the main Makefile automatically
 CFLAGS_PIC += -fPIC
-CXXFLAGS_PIC += -fPIC
 PATH_COMPONENT_SEP = /
 PATH_SEP_CHAR=':'
 DYLIB_SUFFIX = .so

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -25,24 +25,11 @@ COMPILE.c ?= $(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
 	@$(MAKESTEP) "[ CC ] $(<F)"
 	$(COMPILE.c) $(OUTPUT_OPTION) $<
 
-%.o: %.cpp
-	@$(MAKESTEP) "[ CXX ] $(<F)"
-	$(COMPILE.cc) $(OUTPUT_OPTION) $<
-
-%.o: %.cc
-	@$(MAKESTEP) "[ CXX ] $(<F)"
-	$(COMPILE.cc) $(OUTPUT_OPTION) $<
-
 LINK.c ?= $(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH)
 %$(EXE_SUFFIX): %.o
 	@$(MAKESTEP) "[ LD ] $@"
 	$(LINK.c) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-libtenyr%$(DYLIB_SUFFIX): %.cc
-	@$(MAKESTEP) "[ DYLD-CXX ] $@"
-	$(LINK.cc) -o $@ $^ $(LDLIBS)
-
-%,dy.o: CXXFLAGS += $(CXXFLAGS_PIC)
 %,dy.o: CFLAGS += $(CFLAGS_PIC)
 %,dy.o: %.c
 	@$(MAKESTEP) "[ DYCC ] $(<F)"


### PR DESCRIPTION
Our only use for C++ build mechanics was to support AsmJit. Since #32, AsmJit is no longer used, so we can remove the vestigial references to C++.