### PR TITLE
Add an arm64 build to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       arch: arm64
       env:
         - PLATFORM=linux BITS=64
-        - CHECK_RULE=check_sw GCOV= JIT=0 SDL=0
+        - CHECK_RULE=check_sw GCOV= JIT=1 SDL=0
         - PKG_RULE=gzip
     - compiler: "clang"
       language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,14 @@ matrix:
         - PLATFORM=osx   BITS=64 HOST=x86_64
         - CHECK_RULE=check_sw GCOV= JIT=0 SDL=0
         - PKG_RULE=gzip
+    - compiler: "gcc"
+      language: c
+      os: linux
+      arch: arm64
+      env:
+        - PLATFORM=linux BITS=64
+        - CHECK_RULE=check_sw GCOV= JIT=0 SDL=0
+        - PKG_RULE=gzip
     - compiler: "clang"
       language: c
       os: linux


### PR DESCRIPTION
Travis supports ["multi-arch" builds](https://docs.travis-ci.com/user/multi-cpu-architectures/); using them should expose more bugs.