### PR TITLE
Introduce pedantic compiler flags by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
         - PLATFORM=mingw BITS=64 HOST=x86_64
         - CHECK_RULE=check_sw GCOV=  JIT=0 SDL=0
         - PKG_RULE=zip
+        # Older compilers do not recognize some of our pedantic flags
+        - PEDANTIC=
       addons:
         <<: *def_addons
         apt:
@@ -39,6 +41,8 @@ matrix:
         - PLATFORM=mingw BITS=32 HOST=i686
         - CHECK_RULE=check_sw GCOV=  JIT=0 SDL=0
         - PKG_RULE=zip
+        # Older compilers do not recognize some of our pedantic flags
+        - PEDANTIC=
       addons:
         <<: *def_addons
         apt:
@@ -99,6 +103,8 @@ matrix:
         - COVERITY_SCAN_BRANCH_PATTERN="coverity_scan"
         - COVERITY_SCAN_NOTIFICATION_EMAIL="coverity@tenyr.info"
         - COVERITY_SCAN_BUILD_COMMAND="make V=1 all vpi"
+        # Older compilers do not recognize some of our pedantic flags
+        - PEDANTIC=
       addons:
         <<: *def_addons
         apt:
@@ -114,6 +120,8 @@ matrix:
         - PLATFORM=linux BITS=64
         - CHECK_RULE=check_sw GCOV= JIT=0 SDL=0
         - PKG_RULE=gzip
+        # Older compilers do not recognize some of our pedantic flags
+        - PEDANTIC=
     - language: node_js
       node_js:
         - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons: &def_addons
       - version/$(git describe --always --tags --match 'v?.?.?*' $TRAVIS_COMMIT)
 env:
   global:
+    - MAKEFLAGS=e
     - DEPSSRC=$HOME/local
     - C_INCLUDE_PATH=$DEPSSRC/include
     - LIBRARY_PATH=$DEPSSRC/lib

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ tsim_OBJECTS   = $(common_OBJECTS) simif.o asm.o obj.o plugin.o \
 tld_OBJECTS    = $(common_OBJECTS) obj.o
 
 ifeq ($(USE_OWN_SEARCH),1)
+# The interface of lsearch and tsearch is not something we can change.
+lsearch.o tsearch.o: CFLAGS += -Wno-error=cast-qual
+
 tas_OBJECTS   += lsearch.o tsearch.o
 tld_OBJECTS   += lsearch.o tsearch.o
 tsim_OBJECTS  += lsearch.o tsearch.o
@@ -101,6 +104,10 @@ obj.o: CFLAGS += -Wno-stringop-truncation
 asm.o asmif.o $(DEVOBJS) $(PDEVOBJS): CFLAGS += -Wno-unused-parameter
 # link plugin-common data and functions into every plugin
 $(PDEVLIBS): libtenyr%$(DYLIB_SUFFIX): pluginimpl,dy.o $(shared_OBJECTS:%.o=%,dy.o)
+
+# Some casting away of qualifiers is currently deemed unavoidable, at least
+# without running into different warnings.
+tas.o tld.o param.o param,dy.o: CFLAGS += -Wno-error=cast-qual
 
 # flex-generated code we can't control warnings of as easily
 parser.o lexer.o: CFLAGS += -Wno-sign-compare -Wno-unused -Wno-unused-parameter

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ common.o parser.o stream.o: CFLAGS += -Wno-format-nonliteral
 # We cannot control some aspects of the generated lexer or parser.
 lexer.o: CFLAGS += -Wno-missing-prototypes
 parser.o lexer.o: CFLAGS += -Wno-unused-macros
+lexer.o: CFLAGS += -Wno-shorten-64-to-32
 
 # flex-generated code we can't control warnings of as easily
 parser.o lexer.o: CFLAGS += -Wno-sign-compare -Wno-unused -Wno-unused-parameter

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ tld$(EXE_SUFFIX):  tld.o  $(tld_OBJECTS)
 # used to apply to .o only but some make versions built directly from .c
 tas$(EXE_SUFFIX) tsim$(EXE_SUFFIX) tld$(EXE_SUFFIX): DEFINES += BUILD_NAME='$(BUILD_NAME)'
 
+# Padding warnings are not really relevant to this project.
+CFLAGS += -Wno-padded
+
 # Exempt ourselves from string-related warnings we have manually vetted
 asm.o: CFLAGS += -Wno-stringop-overflow
 obj.o: CFLAGS += -Wno-stringop-truncation

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,9 @@ tas.o tld.o param.o param,dy.o: CFLAGS += -Wno-error=cast-qual
 # strings.
 common.o parser.o stream.o: CFLAGS += -Wno-format-nonliteral
 
-# We cannot control some aspects of the generated lexer.
+# We cannot control some aspects of the generated lexer or parser.
 lexer.o: CFLAGS += -Wno-missing-prototypes
+parser.o lexer.o: CFLAGS += -Wno-unused-macros
 
 # flex-generated code we can't control warnings of as easily
 parser.o lexer.o: CFLAGS += -Wno-sign-compare -Wno-unused -Wno-unused-parameter

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,9 @@ tas.o tld.o param.o param,dy.o: CFLAGS += -Wno-error=cast-qual
 # strings.
 common.o parser.o stream.o: CFLAGS += -Wno-format-nonliteral
 
+# We cannot control some aspects of the generated lexer.
+lexer.o: CFLAGS += -Wno-missing-prototypes
+
 # flex-generated code we can't control warnings of as easily
 parser.o lexer.o: CFLAGS += -Wno-sign-compare -Wno-unused -Wno-unused-parameter
 # flex-generated code needs POSIX source for fileno()

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ $(PDEVLIBS): libtenyr%$(DYLIB_SUFFIX): pluginimpl,dy.o $(shared_OBJECTS:%.o=%,dy
 # Some casting away of qualifiers is currently deemed unavoidable, at least
 # without running into different warnings.
 tas.o tld.o param.o param,dy.o: CFLAGS += -Wno-error=cast-qual
+# Calls to variadic printf functions almost always need non-literal format
+# strings.
+common.o parser.o stream.o: CFLAGS += -Wno-format-nonliteral
 
 # flex-generated code we can't control warnings of as easily
 parser.o lexer.o: CFLAGS += -Wno-sign-compare -Wno-unused -Wno-unused-parameter

--- a/hw/vpi/load.c
+++ b/hw/vpi/load.c
@@ -1,7 +1,7 @@
 #include "sim.h"
 #include "stream.h"
 
-#include <vpi_user.h>
+#include "tenyr_vpi.h"
 
 #define MIN(X,Y) ((X) < (Y) ? (X) : (Y))
 

--- a/hw/vpi/tenyr_vpi.h
+++ b/hw/vpi/tenyr_vpi.h
@@ -31,5 +31,13 @@ struct tenyr_sim_state {
     void *extstate; ///< external state possibly used by tenyr_sim_cb's
 };
 
+extern tenyr_sim_cb tenyr_sim_genesis;
+extern tenyr_sim_cb tenyr_sim_apocalypse;
+extern tenyr_sim_cb tenyr_sim_clock;
+
+extern int tenyr_sim_load(struct tenyr_sim_state *state);
+extern int tenyr_sim_putchar(struct tenyr_sim_state *state);
+extern int tenyr_sim_getchar(struct tenyr_sim_state *state);
+
 #endif
 

--- a/hw/vpi/vpidevices.c
+++ b/hw/vpi/vpidevices.c
@@ -6,34 +6,29 @@ static void *pud = (void*)&user_data;
 
 static void register_genesis(void)
 {
-    extern tenyr_sim_cb tenyr_sim_genesis;
     s_cb_data data = { cbStartOfSimulation, tenyr_sim_genesis, NULL, 0, 0, 0, pud };
     pstate->handle.cb.genesis = vpi_register_cb(&data);
 }
 
 static void register_general(void)
 {
-    extern int tenyr_sim_load();
     s_vpi_systf_data load = { vpiSysTask, 0, "$tenyr_load", (int(*)())tenyr_sim_load, NULL, NULL, pud };
     pstate->handle.tf.tenyr_load = vpi_register_systf(&load);
 }
 
 static void register_apocalypse(void)
 {
-    extern tenyr_sim_cb tenyr_sim_apocalypse;
     s_cb_data data = { cbEndOfSimulation, tenyr_sim_apocalypse, NULL, 0, 0, 0, pud };
     pstate->handle.cb.apocalypse = vpi_register_cb(&data);
 }
 
 static void register_serial(void)
 {
-    extern int tenyr_sim_putchar();
-    s_vpi_systf_data put = { vpiSysTask, 0, "$tenyr_putchar", tenyr_sim_putchar, NULL, NULL, pud };
+    s_vpi_systf_data put = { vpiSysTask, 0, "$tenyr_putchar", (int(*)())tenyr_sim_putchar, NULL, NULL, pud };
     pstate->handle.tf.tenyr_putchar = vpi_register_systf(&put);
 #if 0
     // XXX this code is not tenyr-correct -- it can block
-    extern int tenyr_sim_getchar();
-    s_vpi_systf_data get = { vpiSysTask, 0, "$tenyr_getchar", tenyr_sim_getchar, NULL, NULL, pud };
+    s_vpi_systf_data get = { vpiSysTask, 0, "$tenyr_getchar", (int(*)())tenyr_sim_getchar, NULL, NULL, pud };
     pstate->handle.tf.tenyr_getchar = vpi_register_systf(&get);
 #endif
 }

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -66,12 +66,8 @@ endif
 
 CFLAGS += -std=c99
 CFLAGS += -Wall -Wextra -Wshadow $(PEDANTIC_FLAGS)
- #-Wextra $(PEDANTIC_FLAGS)
-ifeq ($(PEDANTIC),)
- PEDANTIC_FLAGS ?= -pedantic
-else
- PEDANTIC_FLAGS ?= -Werror -pedantic-errors
-endif
+
+include $(TOP)/mk/pedantic.mk
 
 COVERAGE_FLAGS = $(if $(GCOV),--coverage -O0)
 CFLAGS   += $(COVERAGE_FLAGS)

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -11,6 +11,9 @@ PEDANTIC_FLAGS += -Wno-unreachable-code-return
 # Our use of __DATE__ and __TIME__ is fine for us.
 PEDANTIC_FLAGS += -Wno-date-time
 
+# Required feature-macros trip this warning spuriously.
+PEDANTIC_FLAGS += -Wno-reserved-id-macro
+
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -14,5 +14,6 @@ PEDANTIC_FLAGS += -Wno-date-time
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum
+PEDANTIC_FLAGS += -Werror=comma
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -8,6 +8,9 @@ PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
 # Unreachable `return` statements after `fatal` are not an error for us.
 PEDANTIC_FLAGS += -Wno-unreachable-code-return
 
+# Our use of __DATE__ and __TIME__ is fine for us.
+PEDANTIC_FLAGS += -Wno-date-time
+
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -7,5 +7,6 @@ PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
 
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
+PEDANTIC_FLAGS += -Werror=switch-enum
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -6,5 +6,6 @@ else
 PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
 
 PEDANTIC_FLAGS += -Werror=covered-switch-default
+PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -20,5 +20,6 @@ PEDANTIC_FLAGS += -Werror=switch-enum
 PEDANTIC_FLAGS += -Werror=comma
 PEDANTIC_FLAGS += -Werror=cast-qual
 PEDANTIC_FLAGS += -Werror=vla
+PEDANTIC_FLAGS += -Werror=strict-prototypes
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -4,4 +4,7 @@ ifeq ($(PEDANTIC),)
 PEDANTIC_FLAGS ?= -pedantic
 else
 PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
+
+PEDANTIC_FLAGS += -Werror=covered-switch-default
+
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -16,5 +16,6 @@ PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum
 PEDANTIC_FLAGS += -Werror=comma
 PEDANTIC_FLAGS += -Werror=cast-qual
+PEDANTIC_FLAGS += -Werror=vla
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -21,5 +21,6 @@ PEDANTIC_FLAGS += -Werror=comma
 PEDANTIC_FLAGS += -Werror=cast-qual
 PEDANTIC_FLAGS += -Werror=vla
 PEDANTIC_FLAGS += -Werror=strict-prototypes
+PEDANTIC_FLAGS += -Werror=missing-prototypes
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -5,6 +5,9 @@ PEDANTIC_FLAGS ?= -pedantic
 else
 PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
 
+# Unreachable `return` statements after `fatal` are not an error for us.
+PEDANTIC_FLAGS += -Wno-unreachable-code-return
+
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -15,5 +15,6 @@ PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum
 PEDANTIC_FLAGS += -Werror=comma
+PEDANTIC_FLAGS += -Werror=cast-qual
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -1,0 +1,7 @@
+PEDANTIC = 1
+
+ifeq ($(PEDANTIC),)
+PEDANTIC_FLAGS ?= -pedantic
+else
+PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
+endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -23,5 +23,6 @@ PEDANTIC_FLAGS += -Werror=vla
 PEDANTIC_FLAGS += -Werror=strict-prototypes
 PEDANTIC_FLAGS += -Werror=missing-prototypes
 PEDANTIC_FLAGS += -Werror=unused-macros
+PEDANTIC_FLAGS += -Werror=shorten-64-to-32
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -22,5 +22,6 @@ PEDANTIC_FLAGS += -Werror=cast-qual
 PEDANTIC_FLAGS += -Werror=vla
 PEDANTIC_FLAGS += -Werror=strict-prototypes
 PEDANTIC_FLAGS += -Werror=missing-prototypes
+PEDANTIC_FLAGS += -Werror=unused-macros
 
 endif

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -10,6 +10,10 @@ libtenyrsdl%$(DYLIB_SUFFIX): LDLIBS += $(call sdl2_pkg_config,--libs,sdl2 SDL2_i
 libtenyrsdlvga$(DYLIB_SUFFIX): | $(TOP)rsrc/font10x15/invert.font10x15.png
 $(TOP)rsrc/font10x15/%:
 	$(MAKE) -C $(@D) $(@F)
+
+# Do not halt the build for platforms on which the feature-flag _BSD_SOURCE is
+# unused.
+sdl%.o: CFLAGS += -Wno-error=unused-macros
 endif
 endif
 

--- a/src/asm.c
+++ b/src/asm.c
@@ -585,8 +585,7 @@ const struct format tenyr_asm_formats[] = {
 const size_t tenyr_asm_formats_count = countof(tenyr_asm_formats);
 
 int make_format_list(int (*pred)(const struct format *), size_t flen,
-        const struct format fmts[flen], size_t len, char buf[len],
-        const char *sep)
+        const struct format *fmts, size_t len, char *buf, const char *sep)
 {
     size_t pos = 0;
     for (const struct format *f = fmts; pos < len && f < fmts + flen; f++)

--- a/src/asm.c
+++ b/src/asm.c
@@ -1,6 +1,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <stdbool.h>
 
 #include "obj.h"
 #include "ops.h"
@@ -55,7 +56,7 @@ static const int op_types[16] = {
     // all others   = OP0
 };
 // This table defines canonical shorthands for certain encodings
-static const struct hides { unsigned a:1, b:1, c:1; }
+static const struct hides { unsigned char a:1, b:1, c:1, :(CHAR_BIT-3); }
 hide[TYPEx][OPx] [2][2][2] = {
     [TYPE0][OP0] [0][0][1] = { 0,0,1 }, // B <- C * D
     [TYPE0][OP1] [0][0][1] = { 0,0,1 }, // B <- C | D
@@ -267,7 +268,6 @@ static int gen_fini(STREAM *stream, void **ud)
  * Object format : simple section-based objects
  */
 struct obj_fdata {
-    int assembling;
     struct obj *o;
     long syms;
     long rlcs;
@@ -278,6 +278,7 @@ struct obj_fdata {
     struct objrlc **next_rlc;
     uint32_t pos;   ///< position in objrec
 
+    int assembling;
     int error;
 };
 
@@ -492,9 +493,9 @@ static int text_out(STREAM *stream, struct element *i, void *ud)
 
 struct memh_state {
     int32_t written, marked, offset;
-    unsigned first_done:1;
     int emit_zeros;
-    unsigned error:1;
+    bool first_done;
+    bool error;
 };
 
 static int memh_init(STREAM *stream, struct param_state *p, void **ud)

--- a/src/asm.c
+++ b/src/asm.c
@@ -382,7 +382,7 @@ static int obj_sym(STREAM *stream, struct symbol *symbol, int flags, void *ud)
         struct objsym *sym = *u->next_sym = calloc(1, sizeof *sym);
 
         sym->name.str = strdup_rounded_up(symbol->name);
-        sym->name.len = strlen(symbol->name);
+        sym->name.len = (UWord)strlen(symbol->name);
         // `symbol->resolved` must be true by this point
         sym->value = symbol->reladdr;
         sym->flags = flags;
@@ -404,9 +404,9 @@ static int obj_reloc(STREAM *stream, struct reloc_node *reloc, void *ud)
 
     struct objrlc *rlc = *u->next_rlc = calloc(1, sizeof *rlc);
 
-    rlc->flags = reloc->flags;
+    rlc->flags = (UWord)reloc->flags;
     rlc->name.str  = reloc->name ? strdup_rounded_up(reloc->name) : NULL;
-    rlc->name.len  = reloc->name ? strlen(reloc->name) : 0;
+    rlc->name.len  = reloc->name ? (UWord)strlen(reloc->name) : 0;
     rlc->addr = reloc->insn->insn.reladdr;
     rlc->width = reloc->width;
     rlc->shift = reloc->shift;
@@ -425,8 +425,8 @@ static int obj_emit(STREAM *stream, void **ud)
 
     if (u->assembling) {
         o->records[0].size = u->pos;
-        o->sym_count = u->syms;
-        o->rlc_count = u->rlcs;
+        o->sym_count = (UWord)u->syms;
+        o->rlc_count = (UWord)u->rlcs;
 
         obj_write(u->o, stream);
     }
@@ -471,7 +471,7 @@ static int text_in(STREAM *stream, struct element *i, void *ud)
     // read "agda"" as "0xa" and subsequently fail, when the whole string
     // should have been rejected.
     char next_char = 0;
-    int len = stream->op.fread(&next_char, 1, 1, stream);
+    size_t len = stream->op.fread(&next_char, 1, 1, stream);
     if (len > 0 && !isspace(next_char))
         return -1;
     return result ? 1 : -1;
@@ -587,7 +587,7 @@ const struct format tenyr_asm_formats[] = {
 
 const size_t tenyr_asm_formats_count = countof(tenyr_asm_formats);
 
-int make_format_list(int (*pred)(const struct format *), size_t flen,
+size_t make_format_list(int (*pred)(const struct format *), size_t flen,
         const struct format *fmts, size_t len, char *buf, const char *sep)
 {
     size_t pos = 0;

--- a/src/asm.c
+++ b/src/asm.c
@@ -109,7 +109,9 @@ static int is_printable(unsigned int ch, char buf[3])
         case '\r': buf[0] = '\\'; buf[1] = 'r' ; return 1;
         case '\t': buf[0] = '\\'; buf[1] = 't' ; return 1;
         case '\v': buf[0] = '\\'; buf[1] = 'v' ; return 1;
-        default: buf[0] = ch; return ch < UCHAR_MAX && isprint((unsigned char)ch);
+        default:
+            buf[0] = (char)ch;
+            return ch < UCHAR_MAX && isprint((unsigned char)ch);
     }
 }
 

--- a/src/asm.c
+++ b/src/asm.c
@@ -180,7 +180,23 @@ int print_disassembly(STREAM *out, const struct element *i, int flags)
                 sA = " ";
                 show3 |= g->p == 0; // append term to disambiguate type0, type2
                 break;
-            default:
+
+            case OP_BITWISE_OR:
+            case OP_BITWISE_AND:
+            case OP_BITWISE_XOR:
+            case OP_SHIFT_RIGHT_ARITH:
+            case OP_ADD:
+            case OP_MULTIPLY:
+            case OP_COMPARE_EQ:
+            case OP_COMPARE_LT:
+            //case OP_BITWISE_ORN:
+            case OP_BITWISE_ANDN:
+            case OP_PACK:
+            case OP_SHIFT_RIGHT_LOGIC:
+            //case OP_SUBTRACT:
+            case OP_SHIFT_LEFT:
+            case OP_TEST_BIT:
+            case OP_COMPARE_GE:
                 break;
         }
     }

--- a/src/asm.h
+++ b/src/asm.h
@@ -40,7 +40,7 @@ int print_registers(STREAM *out, const int32_t regs[16]);
 extern const struct format tenyr_asm_formats[];
 extern const size_t tenyr_asm_formats_count;
 
-int make_format_list(int (*pred)(const struct format *), size_t flen,
+size_t make_format_list(int (*pred)(const struct format *), size_t flen,
         const struct format *fmts, size_t len, char *buf,
         const char *sep);
 

--- a/src/asmif.c
+++ b/src/asmif.c
@@ -240,7 +240,9 @@ static int fixup_deferred_exprs(struct parse_data *pd)
                 rc |= 1;
             }
 
-            uint32_t mask = ~((1LL << r->width) - 1);
+            // The mask may need to be all ones, so we need to compute the mask
+            // in a space larger than 32 bits, before truncating it.
+            uint32_t mask = (uint32_t)~((1ULL << r->width) - 1);
             *r->dest &= mask;
             *r->dest |= result & ~mask;
             ce_free(ce);

--- a/src/cjit.c
+++ b/src/cjit.c
@@ -3,6 +3,8 @@
 #include <search.h>
 #include <stdlib.h>
 
+sim_runner jit_run_sim;
+
 // XXX permit fetch to express failure
 static int32_t fetch(struct sim_state *s, int32_t addr)
 {
@@ -71,7 +73,7 @@ static int post_insn_hook(struct sim_state *s, const struct element *i, void *ud
     return o->ops.post_insn(s, i, o->nested_ops_data);
 }
 
-int jit_run_sim(struct sim_state *s, struct run_ops *ops, void **run_data, void *ops_data)
+int jit_run_sim(struct sim_state *s, const struct run_ops *ops, void **run_data, void *ops_data)
 {
     struct jit_state *js;
     jit_init(&js);

--- a/src/common.c
+++ b/src/common.c
@@ -61,7 +61,7 @@ long long numberise(char *str, int base)
 {
     char *p = str;
     // there are more efficient ways to strip '_' but this one is pretty clear
-    int len = strlen(p);
+    size_t len = strlen(p);
     while ((p = strchr(p, '_')))
         memmove(p, p + 1, len - (p - str));
 

--- a/src/common.h
+++ b/src/common.h
@@ -4,6 +4,7 @@
 #include <setjmp.h>
 #include <search.h>
 #include <string.h>
+#include <limits.h>
 
 #include "ops.h"
 
@@ -59,22 +60,23 @@ extern void (*debug_)(int level, const char *file, int line, const char *func,
 struct element {
     struct insn_or_data insn;
 
+    struct reloc_node *reloc;
+
     struct symbol {
+        struct const_expr *ce;
+        struct symbol *next;
+
         char *name;
         int column;
         int lineno;
         int32_t reladdr;
         uint32_t size;
 
-        unsigned resolved:1;
-        unsigned global:1;
-        unsigned unique:1;  ///< if this symbol comes from a label
-
-        struct const_expr *ce;
-
-        struct symbol *next;
+        unsigned char resolved:1;
+        unsigned char global:1;
+        unsigned char unique:1;  ///< if this symbol comes from a label
+        unsigned :(CHAR_BIT-3);
     } *symbol;
-    struct reloc_node *reloc;
 };
 
 typedef int cmp(const void *, const void*);

--- a/src/device.h
+++ b/src/device.h
@@ -31,6 +31,8 @@ struct device_list {
     struct device_list *next;
 };
 
+typedef int device_adder(struct device *device);
+
 #endif
 
 /* vi: set ts=4 sw=4 et: */

--- a/src/devices/ram.c
+++ b/src/devices/ram.c
@@ -7,9 +7,9 @@
 #include "ram.h"
 
 struct ram_state {
-    uint32_t base;
     size_t memsize;
     uint32_t *mem;
+    uint32_t base;
 };
 
 static int ram_init(struct plugin_cookie *pcookie, struct device *device, void *cookie)

--- a/src/devices/sdlled.c
+++ b/src/devices/sdlled.c
@@ -27,6 +27,9 @@
 
 #define PUMP_CYCLES 2048
 
+library_init tenyr_plugin_init;
+device_adder sdlled_add_device;
+
 struct sdlled_state {
     struct plugin_cookie *pcookie;
     uint32_t data[2];
@@ -239,10 +242,12 @@ static int sdlled_pump(void *cookie)
     return 0;
 }
 
-void EXPORT tenyr_plugin_init(struct guest_ops *ops)
+int EXPORT tenyr_plugin_init(struct guest_ops *ops)
 {
     fatal_ = ops->fatal;
     debug_ = ops->debug;
+
+    return 0;
 }
 
 int EXPORT sdlled_add_device(struct device *device)

--- a/src/devices/sdlled.c
+++ b/src/devices/sdlled.c
@@ -35,10 +35,10 @@ struct sdlled_state {
     uint32_t data[2];
     SDL_Window *window;
     SDL_Renderer *renderer;
-    enum { RUNNING, STOPPING, STOPPED } status;
     SDL_Texture *digits[16];
     SDL_Texture *dots[2];
     struct timeval last_update, deadline;
+    enum { RUNNING, STOPPING, STOPPED } status;
     int cycles;
 };
 

--- a/src/devices/sdlvga.c
+++ b/src/devices/sdlvga.c
@@ -29,6 +29,9 @@
 
 #define PUMP_CYCLES 2048
 
+library_init tenyr_plugin_init;
+device_adder sdlvga_add_device;
+
 struct sdlvga_state {
     uint32_t data[ROWS][COLS];
     SDL_Window *window;
@@ -193,10 +196,12 @@ static int sdlvga_pump(void *cookie)
     return 0;
 }
 
-void EXPORT tenyr_plugin_init(struct guest_ops *ops)
+int EXPORT tenyr_plugin_init(struct guest_ops *ops)
 {
     fatal_ = ops->fatal;
     debug_ = ops->debug;
+
+    return 0;
 }
 
 int EXPORT sdlvga_add_device(struct device *device)

--- a/src/devices/serial.c
+++ b/src/devices/serial.c
@@ -10,6 +10,8 @@
 #define SERIAL_BASE (1ULL << 5)
 #define SERIAL_NO_CHARACTER 0x80000000ull
 
+device_adder serial_add_device;
+
 struct serial_state {
     FILE *in;
     FILE *out;

--- a/src/devices/sparseram.c
+++ b/src/devices/sparseram.c
@@ -9,6 +9,8 @@
 #include "sim.h"
 #include "ram.h"
 
+device_adder sparseram_add_device;
+
 // Allocate space by roughly a page-size (although since there is overhead the
 // fact that it is nearly a page size is basically useless since it does not
 // fit evenly into pages). Consider allocating header ram_elements separately from

--- a/src/devices/sparseram.c
+++ b/src/devices/sparseram.c
@@ -23,8 +23,8 @@ struct sparseram_state {
 };
 
 struct ram_element {
-    int32_t base;
     uint32_t *space;
+    int32_t base;
 };
 
 static int tree_compare(const void *_a, const void *_b)

--- a/src/devices/sparseram.c
+++ b/src/devices/sparseram.c
@@ -40,7 +40,7 @@ static int sparseram_init(struct plugin_cookie *pcookie, struct device *device, 
     sparseram->mem = NULL;
     sparseram->pagesize = os_getpagesize();
     // `mask` has only the bits set that address *within* a page
-    sparseram->mask = sparseram->pagesize / sizeof(uint32_t) - 1;
+    sparseram->mask = (unsigned int)(sparseram->pagesize / sizeof(uint32_t) - 1);
 
     return 0;
 }

--- a/src/expr.h
+++ b/src/expr.h
@@ -44,6 +44,7 @@ struct const_expr_list {
 };
 
 struct expr {
+    struct const_expr *ce;
     int type;   ///< type{0,1,2,3}
     int deref;
     int x;
@@ -51,7 +52,6 @@ struct expr {
     int y;
     int32_t i;
     int mult;   ///< multiplier from addsub
-    struct const_expr *ce;
 };
 
 #endif

--- a/src/jit.h
+++ b/src/jit.h
@@ -7,14 +7,15 @@
 typedef void Block(struct sim_state *sim, int32_t *registers);
 
 struct jit_state {
-    void *nested_run_data;
-    struct sim_state *sim_state;
-    int run_count_threshold;
+    void *jj;
+
     struct {
         int32_t (*fetch)(struct sim_state *s, int32_t addr);
         void (*store)(struct sim_state *s, int32_t addr, int32_t value);
     } ops;
-    void *jj;
+    void *nested_run_data;
+    struct sim_state *sim_state;
+    int run_count_threshold;
 };
 
 struct ops_state {
@@ -26,11 +27,11 @@ struct ops_state {
 };
 
 struct basic_block {
+    Block *compiled;
+    int32_t *cache;
     int run_count;
     int32_t base;
     uint32_t len;
-    Block *compiled;
-    int32_t *cache;
 };
 
 void jit_init(struct jit_state **state);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -12,7 +12,7 @@ int tenyr_error(YYLTYPE *locp, struct parse_data *pd, const char *s, ...);
 
 static struct cstr *resizestr(struct cstr *s, size_t len);
 static int savestr(const char *text, size_t len, yyscan_t yyscanner);
-#define savechr(ch,sc) savestr((const char[]){ ch },1,sc)
+#define savechr(ch,sc) savestr((const char[]){ (char)(ch) },1,sc)
 static int translate_escape(YYLTYPE *loc, struct parse_data *extra, int what);
 
 #define savecol  (yyextra->lexstate.savecol)

--- a/src/lsearch.c
+++ b/src/lsearch.c
@@ -3,6 +3,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+// em.h defines these prototypes, but this file should not need to depend on
+// that header.
+void *lfind(const void *key, const void *base, size_t *nelp, size_t width, int (*compar)(const void *, const void *));
+void *lsearch(const void *key, void *base, size_t *nelp, size_t width, int (*compar)(const void *, const void *));
+
 void *lfind(const void *key, const void *base, size_t *nelp, size_t width, int (*compar)(const void *, const void *))
 {
     char *where = (void*)base;

--- a/src/obj.c
+++ b/src/obj.c
@@ -298,7 +298,7 @@ static int get_syms_v1(struct obj *o, STREAM *in, void *context)
         sym->name.str = malloc(SYMBOL_LEN_V1 + sizeof '\0');
         get_sized(sym->name.str, SYMBOL_LEN_V1, 1, in);
         sym->name.str[SYMBOL_LEN_V1] = '\0';
-        sym->name.len = strlen(sym->name.str);
+        sym->name.len = (UWord)strlen(sym->name.str);
         GET(sym->value, in);
         GET(sym->size, in);
     }
@@ -345,7 +345,7 @@ static int get_relocs_v0(struct obj *o, STREAM *in, void *context)
         rlc->name.str = malloc(SYMBOL_LEN_V1 + sizeof '\0');
         get_sized(rlc->name.str, SYMBOL_LEN_V1, 1, in);
         rlc->name.str[SYMBOL_LEN_V1] = '\0';
-        rlc->name.len = strlen(rlc->name.str);
+        rlc->name.len = (UWord)strlen(rlc->name.str);
         GET(rlc->addr, in);
         GET(rlc->width, in);
         rlc->shift = 0;
@@ -394,7 +394,7 @@ static int get_relocs_v1(struct obj *o, STREAM *in, void *context)
         rlc->name.str = malloc(SYMBOL_LEN_V1 + sizeof '\0');
         get_sized(rlc->name.str, SYMBOL_LEN_V1, 1, in);
         rlc->name.str[SYMBOL_LEN_V1] = '\0';
-        rlc->name.len = strlen(rlc->name.str);
+        rlc->name.len = (UWord)strlen(rlc->name.str);
         GET(rlc->addr, in);
         GET(rlc->width, in);
         GET(rlc->shift, in);

--- a/src/obj.h
+++ b/src/obj.h
@@ -18,8 +18,8 @@ typedef uint32_t UWord;
 typedef  int32_t SWord;
 
 struct name {
-    UWord len;
     char *str;
+    UWord len;
 };
 
 struct obj {

--- a/src/os/Darwin/findself.c
+++ b/src/os/Darwin/findself.c
@@ -1,9 +1,12 @@
+#include "os_common.h"
+
 #include <libproc.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-char *os_find_self(void)
+char *os_find_self(const char *argv0)
 {
+    (void)argv0;
     size_t size = PROC_PIDPATHINFO_MAXSIZE;
     char *path = malloc(size);
     if (proc_pidpath(getpid(), path, size) > 0) {

--- a/src/os/Darwin/findself.c
+++ b/src/os/Darwin/findself.c
@@ -7,7 +7,7 @@
 char *os_find_self(const char *argv0)
 {
     (void)argv0;
-    size_t size = PROC_PIDPATHINFO_MAXSIZE;
+    uint32_t size = PROC_PIDPATHINFO_MAXSIZE;
     char *path = malloc(size);
     if (proc_pidpath(getpid(), path, size) > 0) {
         return path;

--- a/src/os/Linux/findself.c
+++ b/src/os/Linux/findself.c
@@ -1,9 +1,12 @@
 #define _XOPEN_SOURCE 500
+#include "os_common.h"
+
 #include <unistd.h>
 #include <stdlib.h>
 
-char *os_find_self(void)
+char *os_find_self(const char *argv0)
 {
+    (void)argv0;
     // PATH_MAX (used by readlink(2)) is not necessarily available
     size_t size = 2048, used = 0;
     char *path = NULL;

--- a/src/os/Win32/findself.c
+++ b/src/os/Win32/findself.c
@@ -1,8 +1,10 @@
+#include "os_common.h"
+
 #include <windows.h>
 #include <limits.h>
 #include <stddef.h>
 
-char *os_find_self(void)
+char *os_find_self(const char *argv0)
 {
     size_t size = PATH_MAX;
     char *buf = malloc(size);

--- a/src/os/Win32/os_common.h
+++ b/src/os/Win32/os_common.h
@@ -29,8 +29,8 @@ struct param_state;
 char *os_find_self(const char *);
 FILE *os_fopen(const char *, const char *);
 int os_get_tsimrc_path(char buf[], size_t sz);
-long os_getpagesize();
-int os_preamble();
+long os_getpagesize(void);
+int os_preamble(void);
 int os_set_buffering(FILE *stream, int mode);
 int os_set_non_blocking(FILE *stream);
 

--- a/src/os/default/emscripten.c
+++ b/src/os/default/emscripten.c
@@ -2,6 +2,9 @@
 
 struct sim_state;
 
+// In lieu of a header, provide a prototype for -Wmissing-prototypes.
+int recipe_emscript(struct sim_state *s);
+
 int recipe_emscript(struct sim_state *s)
 {
     (void)s;

--- a/src/os/default/linebuf.c
+++ b/src/os/default/linebuf.c
@@ -1,3 +1,5 @@
+#include "os_common.h"
+
 #include <stdio.h>
 
 int os_set_buffering(FILE *stream, int mode)

--- a/src/os/default/open.c
+++ b/src/os/default/open.c
@@ -1,5 +1,7 @@
 #define _XOPEN_SOURCE 700 /* for fileno */
 
+#include "os_common.h"
+
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/os/default/os_common.h
+++ b/src/os/default/os_common.h
@@ -9,8 +9,8 @@ typedef size_t lfind_size_t;
 char *os_find_self(const char *);
 FILE *os_fopen(const char *, const char *);
 int os_get_tsimrc_path(char buf[], size_t sz);
-long os_getpagesize();
-int os_preamble();
+long os_getpagesize(void);
+int os_preamble(void);
 int os_set_buffering(FILE *stream, int mode);
 int os_set_non_blocking(FILE *stream);
 

--- a/src/os/default/pagesize.c
+++ b/src/os/default/pagesize.c
@@ -1,3 +1,5 @@
+#include "os_common.h"
+
 #include <unistd.h>
 
 long os_getpagesize()

--- a/src/os/default/preamble.c
+++ b/src/os/default/preamble.c
@@ -1,3 +1,4 @@
+#include "os_common.h"
 #include "param.h"
 
 int os_preamble(void)

--- a/src/os/default/preamble.c
+++ b/src/os/default/preamble.c
@@ -1,6 +1,6 @@
 #include "param.h"
 
-int os_preamble()
+int os_preamble(void)
 {
     // no action required in default case
     return 0;

--- a/src/os/emscripten/emscripten.c
+++ b/src/os/emscripten/emscripten.c
@@ -1,6 +1,9 @@
 #include "emscripten.h"
 #include "sim.h"
 
+// In lieu of a header, provide a prototype for -Wmissing-prototypes.
+int recipe_emscript(struct sim_state *s);
+
 struct emscripten_wrap {
     struct sim_state *s;
     const struct run_ops *ops;

--- a/src/os/emscripten/findself.c
+++ b/src/os/emscripten/findself.c
@@ -1,6 +1,8 @@
+#include "os_common.h"
+
 #include <stdlib.h>
 
-char *os_find_self(char *argv0)
+char *os_find_self(const char *argv0)
 {
     (void)argv0;
     // This value is not used by its caller as of the time of writing -- this

--- a/src/os/emscripten/open.c
+++ b/src/os/emscripten/open.c
@@ -1,3 +1,5 @@
+#include "os_common.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/os/emscripten/preamble.c
+++ b/src/os/emscripten/preamble.c
@@ -3,7 +3,9 @@
 #include <unistd.h>
 #include "param.h"
 
-int os_preamble()
+#include "os_common.h"
+
+int os_preamble(void)
 {
     if (access("/dev/zero", R_OK))
         EM_ASM(({ FS.createDevice('/dev', 'zero', function () { return 0; }); }),/* dummy arg */0);

--- a/src/param.c
+++ b/src/param.c
@@ -50,7 +50,7 @@ int param_get_int(struct param_state *pstate, const char *key, int *val)
 
 // Returns the number of parameters with the given key, filling the first
 // `count` of them into the supplied `val` array
-int param_get(struct param_state *pstate, const char *key, size_t count, const void *val[count])
+int param_get(struct param_state *pstate, const char *key, size_t count, const void **val)
 {
     if (!pstate) return 0; // permit calling with NULL param set
 

--- a/src/param.c
+++ b/src/param.c
@@ -17,8 +17,8 @@ struct param_state {
         unsigned free_key:1;
         struct string_list {
             struct string_list *next;
-            unsigned free_value:1; ///< whether value should be free()d
             void *value;
+            unsigned free_value; ///< whether value should be free()d
         } *list;
     } *params;
 };

--- a/src/param.c
+++ b/src/param.c
@@ -37,13 +37,13 @@ int param_get_int(struct param_state *pstate, const char *key, int *val)
 {
     const char *str = NULL;
     char *next = NULL;
-    int test = 0;
+    long test = 0;
     if (param_get(pstate, key, 1, (const void **)&str) && str != NULL)
         test = strtol(str, &next, 0);
 
     int good = next > str;
     if (good)
-        *val = test;
+        *val = (int)test;
 
     return good;
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -54,9 +54,6 @@ static void do_option(struct parse_data *pd, YYLTYPE *locp,
 
 // XXX decide whether this should be called in functions or in grammar actions
 static void free_cstr(struct cstr *cs, int recurse);
-extern struct symbol *symbol_find(struct symbol_list *list, const char *name);
-extern void tenyr_push_state(int st, void *yyscanner);
-extern void tenyr_pop_state(void *yyscanner);
 %}
 
 %define parse.error verbose

--- a/src/parser.y
+++ b/src/parser.y
@@ -748,7 +748,8 @@ static void handle_directive(struct parse_data *pd, YYLTYPE *locp,
             sym->ce->deferred = context;
             break;
         }
-        default:
+        case D_NULL:
+        case D_ZERO:
             tenyr_error(locp, pd, "Unknown directive type %d in %s",
                         d->type, __func__);
     }

--- a/src/parser_global.h
+++ b/src/parser_global.h
@@ -14,10 +14,10 @@ struct parse_data {
     struct deferred_expr {
         struct const_expr *ce;
         uint32_t *dest;     ///< destination word to be updated
+        struct deferred_expr *next;
         int width;          ///< width in bits of the right-justified immediate
         int mult;           ///< multiplier (1 or -1, according to sign)
         int flags;          ///< flags used by ce_eval
-        struct deferred_expr *next;
     } *defexprs;
     struct symbol_list {
         struct symbol *symbol;
@@ -40,16 +40,16 @@ struct parse_data {
 };
 
 struct cstr {
-    int size;
     char *head, *tail;
     struct cstr *last, *right;
+    int size;
 };
 
 struct directive {
+    void *data;
     enum directive_type {
         D_NULL, D_GLOBAL, D_SET, D_ZERO
     } type;
-    void *data;
 };
 
 int tenyr_parse(struct parse_data *);

--- a/src/parser_global.h
+++ b/src/parser_global.h
@@ -53,6 +53,9 @@ struct directive {
 };
 
 int tenyr_parse(struct parse_data *);
+struct symbol *symbol_find(struct symbol_list *list, const char *name);
+void tenyr_push_state(int st, void *yyscanner);
+void tenyr_pop_state(void *yyscanner);
 
 #endif
 

--- a/src/plugin_portable.h
+++ b/src/plugin_portable.h
@@ -39,6 +39,10 @@ typedef int plugin_success_cb(void *libhandle, int inst, const char *parent,
 int plugin_load(const char *basepath, const char **paths, const char *base,
         const struct plugin_cookie *p, plugin_success_cb *success, void *ud);
 
+// These are the implementations of the `common` functions, plugin version.
+extern void (* NORETURN fatal_)(int code, const char *file, int line, const char *func, const char *fmt, ...);
+extern void (*          debug_)(int level, const char *file, int line, const char *func, const char *fmt, ...);
+
 #endif
 
 /* vi: set ts=4 sw=4 et: */

--- a/src/sim.c
+++ b/src/sim.c
@@ -85,7 +85,7 @@ static int do_common(struct sim_state *s, int32_t *Z, int32_t *rhs,
     return 0;
 }
 
-int run_instruction(struct sim_state *s, const struct element *i, void *run_data)
+static int run_instruction(struct sim_state *s, const struct element *i, void *run_data)
 {
     (void)run_data;
     int32_t * const ip = &s->machine.regs[15];

--- a/src/sim.c
+++ b/src/sim.c
@@ -29,7 +29,8 @@ static void do_op(enum op op, int type, int32_t *rhs, uint32_t X, uint32_t Y,
     uint32_t pack1 = Pu(1) & 0xfff;
     int32_t  pack0 = Ps(0);
 
-    switch (op) {
+    // This switch is exhaustive for the four bit opcode.
+    switch (op & 0xf) {
         case OP_ADD               : *rhs =  (Ps(2) +  Ps(1)) + Ps(0); break;
         case OP_SUBTRACT          : *rhs =  (Ps(2) -  Ps(1)) + Ps(0); break;
         case OP_MULTIPLY          : *rhs =  (Ps(2) *  Ps(1)) + Ps(0); break;
@@ -51,9 +52,6 @@ static void do_op(enum op op, int type, int32_t *rhs, uint32_t X, uint32_t Y,
 
         case OP_PACK              : *rhs =  (pack2 |  pack1) + pack0; break;
         case OP_TEST_BIT          : *rhs = -!!(Ps(2) & (1 << Ps(1))) + Ps(0); break;
-
-        default:
-            fatal(0, "Encountered illegal opcode %d", op);
     }
     #undef Ps
     #undef Pu

--- a/src/sim.c
+++ b/src/sim.c
@@ -170,7 +170,7 @@ int interp_run_sim(struct sim_state *s, const struct run_ops *ops,
 }
 
 int load_sim(op_dispatcher *dispatch, void *sud, const struct format *f,
-        void *ud, STREAM *in, int load_address)
+        void *ud, STREAM *in, uint32_t load_address)
 {
     struct element i;
     while (f->in(in, &i, ud) >= 0) {

--- a/src/sim.h
+++ b/src/sim.h
@@ -41,8 +41,8 @@ struct sim_state {
 
         struct param_state *params;
 
-        int start_addr;
-        int load_addr;
+        uint32_t start_addr;
+        uint32_t load_addr;
         const struct format *fmt;
         char *tsim_path;
     } conf;
@@ -77,7 +77,7 @@ struct run_ops {
 
 extern sim_runner interp_run_sim, interp_step_sim;
 int load_sim(op_dispatcher *dispatch_op, void *sud, const struct format *f,
-        void *fud, STREAM *in, int load_address);
+        void *fud, STREAM *in, uint32_t load_address);
 
 #define breakpoint(...) \
     fatal(0, __VA_ARGS__)

--- a/src/tld.c
+++ b/src/tld.c
@@ -105,7 +105,7 @@ static int do_unload(struct link_state *s)
 
 static int ptrcmp(const void *a, const void *b)
 {
-    return *(const char* const*)a - *(const char* const*)b;
+    return (int)(*(const char* const*)a - *(const char* const*)b);
 }
 
 static int def_str_cmp(const void *a, const void *b)
@@ -281,9 +281,9 @@ static int do_link_emit(struct link_state *s, struct obj *o)
 
     o->records = front;
 
-    o->rec_count = rec_count;
-    o->sym_count = s->syms;
-    o->rlc_count = s->rlcs;
+    o->rec_count = (UWord)rec_count;
+    o->sym_count = (UWord)s->syms;
+    o->rlc_count = (UWord)s->rlcs;
 
     return 0;
 }

--- a/src/tld.c
+++ b/src/tld.c
@@ -105,7 +105,7 @@ static int do_unload(struct link_state *s)
 
 static int ptrcmp(const void *a, const void *b)
 {
-    return *(const char**)a - *(const char**)b;
+    return *(const char* const*)a - *(const char* const*)b;
 }
 
 static int def_str_cmp(const void *a, const void *b)

--- a/src/tld.c
+++ b/src/tld.c
@@ -251,7 +251,7 @@ static int do_link_process(struct link_state *s)
     return 0;
 }
 
-int do_link_emit(struct link_state *s, struct obj *o)
+static int do_link_emit(struct link_state *s, struct obj *o)
 {
     long rec_count = 0;
     // copy records
@@ -309,7 +309,7 @@ static int do_emit(struct link_state *s, STREAM *out)
     return rc;
 }
 
-int do_load_all(struct link_state *s, int count, char **names)
+static int do_load_all(struct link_state *s, int count, char **names)
 {
     int rc = 0;
 

--- a/src/tld.c
+++ b/src/tld.c
@@ -309,7 +309,7 @@ static int do_emit(struct link_state *s, STREAM *out)
     return rc;
 }
 
-int do_load_all(struct link_state *s, int count, char *names[count])
+int do_load_all(struct link_state *s, int count, char **names)
 {
     int rc = 0;
 

--- a/src/tsearch.c
+++ b/src/tsearch.c
@@ -15,6 +15,9 @@ typedef int  cmp(const void *key1, const void *key2);
 typedef void act(const void *node, VISIT order, int level);
 typedef void freer(void *node);
 
+// A prototype for tdestroy may not yet exist.
+void tdestroy(void *root, freer *free_node);
+
 // guaranteed to return a non-NULL pointer (might be a pointer to NULL)
 static struct tree **traverse(const void *key, struct tree **rootp, cmp *compar,
                               int create, struct tree **parent)

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -365,7 +365,7 @@ static int parse_opts_file(struct sim_state *s, const char *filename)
     char buf[1024], *p;
     while ((p = fgets(buf, sizeof buf, f))) {
         // trim newline
-        int len = strlen(buf);
+        size_t len = strlen(buf);
         if (buf[len - 1] == '\n')
             buf[len - 1] = '\0';
 
@@ -410,13 +410,13 @@ static int parse_args(struct sim_state *s, int argc, char *argv[])
     while ((ch = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
         switch (ch) {
             case '@': if (parse_opts_file(s, optarg)) fatal(PRINT_ERRNO, "Error in opts file"); break;
-            case 'a': s->conf.load_addr = strtol(optarg, NULL, 0); break;
+            case 'a': s->conf.load_addr = (uint32_t)strtol(optarg, NULL, 0); break;
             case 'd': s->conf.debugging = 1; break;
             case 'f': if (find_format(optarg, &s->conf.fmt)) exit(usage(argv[0], EXIT_FAILURE)); break;
             case 'n': s->conf.run_defaults = 0; break;
             case 'p': param_add(s->conf.params, optarg); break;
             case 'r': if (add_recipe(s, optarg)) exit(usage(argv[0], EXIT_FAILURE)); break;
-            case 's': s->conf.start_addr = strtol(optarg, NULL, 0); break;
+            case 's': s->conf.start_addr = (uint32_t)strtol(optarg, NULL, 0); break;
             case 'v': s->conf.verbose++; break;
 
             case 'V': puts(version()); exit(EXIT_SUCCESS);

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -334,7 +334,7 @@ static int add_recipe(struct sim_state *s, const char *name)
     }
 }
 
-static int plugin_param_get(const struct plugin_cookie *cookie, const char *key, size_t count, const void *val[count])
+static int plugin_param_get(const struct plugin_cookie *cookie, const char *key, size_t count, const void **val)
 {
     return param_get(cookie->param, key, count, val);
 }

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -273,7 +273,7 @@ static int recipe_top_page(struct sim_state *s)
 #define DEVICE_RECIPE_TMPL(Name,Func)                                          \
     static int recipe_##Name(struct sim_state *s)                              \
     {                                                                          \
-        int Func(struct device *device);                                       \
+        device_adder Func;                                                     \
         return Func(new_device(s));                                            \
     }                                                                          \
     //


### PR DESCRIPTION
This pull request brings us close to compliance with `-Werror -Weverything`, with the following exceptions:

- `-Wno-unreachable-code-return`
- `-Wno-date-time`
- `-Wno-reserved-id-macro`
- `-Wno-padded`
- `-Wno-sign-conversion`

at least for `Apple LLVM version 10.0.1 (clang-1001.0.46.4)`. The `sign-conversion` warning has dozens of issues that still need to be looked into, which can be done in a separate pull request.

Eventually it would be nice to enable `-Weverything` itself, but for now, individual flags are enabled in a new file, `mk/pedantic.mk`.

Building on older compilers needs `make PEDANTIC=` in order not to choke on the warnings flags themselves. If the older compilers had `-Wno-unknown-warning-option` or similar, this would be more easily avoidable. The `PEDANTIC=` override is done in Travis already, but users compiling on some systems (MinGW) will need to apply it themselves unless we figure out a way to detect it for them.