### PR TITLE
Allow GCC to build without `PEDANTIC` forced off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
         - PLATFORM=mingw BITS=64 HOST=x86_64
         - CHECK_RULE=check_sw GCOV=  JIT=0 SDL=0
         - PKG_RULE=zip
-        # Older compilers do not recognize some of our pedantic flags
-        - PEDANTIC=
       addons:
         <<: *def_addons
         apt:
@@ -41,8 +39,6 @@ matrix:
         - PLATFORM=mingw BITS=32 HOST=i686
         - CHECK_RULE=check_sw GCOV=  JIT=0 SDL=0
         - PKG_RULE=zip
-        # Older compilers do not recognize some of our pedantic flags
-        - PEDANTIC=
       addons:
         <<: *def_addons
         apt:
@@ -103,8 +99,6 @@ matrix:
         - COVERITY_SCAN_BRANCH_PATTERN="coverity_scan"
         - COVERITY_SCAN_NOTIFICATION_EMAIL="coverity@tenyr.info"
         - COVERITY_SCAN_BUILD_COMMAND="make V=1 all vpi"
-        # Older compilers do not recognize some of our pedantic flags
-        - PEDANTIC=
       addons:
         <<: *def_addons
         apt:
@@ -120,8 +114,6 @@ matrix:
         - PLATFORM=linux BITS=64
         - CHECK_RULE=check_sw GCOV= JIT=0 SDL=0
         - PKG_RULE=gzip
-        # Older compilers do not recognize some of our pedantic flags
-        - PEDANTIC=
     - language: node_js
       node_js:
         - node

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ tld_OBJECTS    = $(common_OBJECTS) obj.o
 
 ifeq ($(USE_OWN_SEARCH),1)
 # The interface of lsearch and tsearch is not something we can change.
-lsearch.o tsearch.o: CFLAGS += -Wno-error=cast-qual
+lsearch.o tsearch.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)cast-qual
 
 tas_OBJECTS   += lsearch.o tsearch.o
 tld_OBJECTS   += lsearch.o tsearch.o
@@ -110,7 +110,7 @@ $(PDEVLIBS): libtenyr%$(DYLIB_SUFFIX): pluginimpl,dy.o $(shared_OBJECTS:%.o=%,dy
 
 # Some casting away of qualifiers is currently deemed unavoidable, at least
 # without running into different warnings.
-tas.o tld.o param.o param,dy.o: CFLAGS += -Wno-error=cast-qual
+tas.o tld.o param.o param,dy.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)cast-qual
 # Calls to variadic printf functions almost always need non-literal format
 # strings.
 common.o parser.o stream.o: CFLAGS += -Wno-format-nonliteral

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,6 @@ tas$(EXE_SUFFIX) tsim$(EXE_SUFFIX) tld$(EXE_SUFFIX): DEFINES += BUILD_NAME='$(BU
 # Padding warnings are not really relevant to this project.
 CFLAGS += -Wno-padded
 
-# Exempt ourselves from string-related warnings we have manually vetted
-asm.o: CFLAGS += -Wno-stringop-overflow
-obj.o: CFLAGS += -Wno-stringop-truncation
 # don't complain about unused state
 asm.o asmif.o $(DEVOBJS) $(PDEVOBJS): CFLAGS += -Wno-unused-parameter
 # link plugin-common data and functions into every plugin

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -4,6 +4,7 @@
 # Provide a short identifier (e.g. "clang" or "gcc") to switch some build-time
 # behaviors (e.g. diagnostic fatalization).
 COMPILER = $(if $(TRAVIS_COMPILER),$(TRAVIS_COMPILER),default)
+include $(TOP)/mk/compiler/default.mk
 -include $(TOP)/mk/compiler/$(COMPILER).mk
 
 ECHO := $(shell which echo)

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,6 +1,11 @@
 # delete all build products built by a rule that exits nonzero
 .DELETE_ON_ERROR:
 
+# Provide a short identifier (e.g. "clang" or "gcc") to switch some build-time
+# behaviors (e.g. diagnostic fatalization).
+COMPILER = $(if $(TRAVIS_COMPILER),$(TRAVIS_COMPILER),default)
+-include $(TOP)/mk/compiler/$(COMPILER).mk
+
 ECHO := $(shell which echo)
 EMPTY :=#
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,12 +1,6 @@
 # delete all build products built by a rule that exits nonzero
 .DELETE_ON_ERROR:
 
-# Provide a short identifier (e.g. "clang" or "gcc") to switch some build-time
-# behaviors (e.g. diagnostic fatalization).
-COMPILER = $(if $(TRAVIS_COMPILER),$(TRAVIS_COMPILER),default)
-include $(TOP)/mk/compiler/default.mk
--include $(TOP)/mk/compiler/$(COMPILER).mk
-
 ECHO := $(shell which echo)
 EMPTY :=#
 
@@ -120,6 +114,12 @@ include $(TOP)/mk/os/vars/default.mk
 # OS Makefiles might have set CROSS_COMPILE. Since we are using `:=` instead of
 # `=`, order of assignment of variables matters.
 CC  := $(CROSS_COMPILE)$(CC)
+
+# Provide a short identifier (e.g. "clang" or "gcc") to switch some build-time
+# behaviors (e.g. diagnostic fatalization).
+COMPILER = $(shell echo __clang_version__ | cc -E -P - | grep -qL __clang_version__ && echo gcc || echo clang)
+include $(TOP)/mk/compiler/default.mk
+-include $(TOP)/mk/compiler/$(COMPILER).mk
 
 include $(TOP)/mk/sdl.mk
 include $(TOP)/mk/jit.mk

--- a/mk/compiler/clang.mk
+++ b/mk/compiler/clang.mk
@@ -1,0 +1,3 @@
+# Our use of Clang can still raise warnings for exceptional cases, instead of
+# suppressing all instances of the warning.
+PEDANTRY_EXCEPTION = no-error=

--- a/mk/compiler/clang.mk
+++ b/mk/compiler/clang.mk
@@ -1,3 +1,9 @@
 # Our use of Clang can still raise warnings for exceptional cases, instead of
 # suppressing all instances of the warning.
 PEDANTRY_EXCEPTION = no-error=
+
+# Clang supports some specific errors we cannot enable on GCC.
+PEDANTIC_FLAGS += -Werror=covered-switch-default
+PEDANTIC_FLAGS += -Werror=missing-variable-declarations
+PEDANTIC_FLAGS += -Werror=comma
+PEDANTIC_FLAGS += -Werror=shorten-64-to-32

--- a/mk/compiler/default.mk
+++ b/mk/compiler/default.mk
@@ -1,0 +1,4 @@
+# Our default way to handle exceptions to fatal warnings is to suppress them
+# entirely. Some compilers (see clang.mk) can raise a non-fatal warning
+# instead.
+PEDANTRY_EXCEPTION = no-

--- a/mk/compiler/gcc.mk
+++ b/mk/compiler/gcc.mk
@@ -1,0 +1,3 @@
+# Exempt ourselves from string-related warnings we have manually vetted
+asm.o: CFLAGS += -Wno-stringop-overflow
+obj.o: CFLAGS += -Wno-stringop-truncation

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -15,6 +15,8 @@ PEDANTIC_FLAGS += -Wno-date-time
 PEDANTIC_FLAGS += -Wno-reserved-id-macro
 PEDANTIC_FLAGS += -Wno-error=cpp
 
+# The following errors are meant to be absent, and therefore their presence is
+# fatal except where elsewhere overridden on a per-object basis.
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -17,15 +17,11 @@ PEDANTIC_FLAGS += -W$(PEDANTRY_EXCEPTION)cpp
 
 # The following errors are meant to be absent, and therefore their presence is
 # fatal except where elsewhere overridden on a per-object basis.
-PEDANTIC_FLAGS += -Werror=covered-switch-default
-PEDANTIC_FLAGS += -Werror=missing-variable-declarations
 PEDANTIC_FLAGS += -Werror=switch-enum
-PEDANTIC_FLAGS += -Werror=comma
 PEDANTIC_FLAGS += -Werror=cast-qual
 PEDANTIC_FLAGS += -Werror=vla
 PEDANTIC_FLAGS += -Werror=strict-prototypes
 PEDANTIC_FLAGS += -Werror=missing-prototypes
 PEDANTIC_FLAGS += -Werror=unused-macros
-PEDANTIC_FLAGS += -Werror=shorten-64-to-32
 
 endif

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -1,9 +1,11 @@
 PEDANTIC = 1
 
+PEDANTRY_EXCEPTION = no-error=
+
 ifeq ($(PEDANTIC),)
 PEDANTIC_FLAGS ?= -pedantic
 else
-PEDANTIC_FLAGS ?= -Werror -pedantic-errors -Wno-error=unknown-warning-option
+PEDANTIC_FLAGS ?= -Werror -pedantic-errors -W$(PEDANTRY_EXCEPTION)unknown-warning-option
 
 # Unreachable `return` statements after `fatal` are not an error for us.
 PEDANTIC_FLAGS += -Wno-unreachable-code-return
@@ -13,7 +15,7 @@ PEDANTIC_FLAGS += -Wno-date-time
 
 # Required feature-macros trip these warnings spuriously.
 PEDANTIC_FLAGS += -Wno-reserved-id-macro
-PEDANTIC_FLAGS += -Wno-error=cpp
+PEDANTIC_FLAGS += -W$(PEDANTRY_EXCEPTION)cpp
 
 # The following errors are meant to be absent, and therefore their presence is
 # fatal except where elsewhere overridden on a per-object basis.

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -1,7 +1,5 @@
 PEDANTIC = 1
 
-PEDANTRY_EXCEPTION = no-error=
-
 ifeq ($(PEDANTIC),)
 PEDANTIC_FLAGS ?= -pedantic
 else

--- a/mk/pedantic.mk
+++ b/mk/pedantic.mk
@@ -11,8 +11,9 @@ PEDANTIC_FLAGS += -Wno-unreachable-code-return
 # Our use of __DATE__ and __TIME__ is fine for us.
 PEDANTIC_FLAGS += -Wno-date-time
 
-# Required feature-macros trip this warning spuriously.
+# Required feature-macros trip these warnings spuriously.
 PEDANTIC_FLAGS += -Wno-reserved-id-macro
+PEDANTIC_FLAGS += -Wno-error=cpp
 
 PEDANTIC_FLAGS += -Werror=covered-switch-default
 PEDANTIC_FLAGS += -Werror=missing-variable-declarations

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -13,7 +13,7 @@ $(TOP)rsrc/font10x15/%:
 
 # Do not halt the build for platforms on which the feature-flag _BSD_SOURCE is
 # unused.
-sdl%.o: CFLAGS += -Wno-error=unused-macros
+sdl%.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)unused-macros
 endif
 endif
 

--- a/src/os/Win32/findself.c
+++ b/src/os/Win32/findself.c
@@ -6,6 +6,7 @@
 
 char *os_find_self(const char *argv0)
 {
+    (void)argv0;
     size_t size = PATH_MAX;
     char *buf = malloc(size);
     if (GetModuleFileName(NULL, buf, size) > 0) {

--- a/src/os/Win32/linebuf.c
+++ b/src/os/Win32/linebuf.c
@@ -1,3 +1,5 @@
+#include "os_common.h"
+
 #include <stdio.h>
 
 int os_set_buffering(FILE *stream, int mode)

--- a/src/os/Win32/open.c
+++ b/src/os/Win32/open.c
@@ -1,3 +1,5 @@
+#include "os_common.h"
+
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/os/Win32/pagesize.c
+++ b/src/os/Win32/pagesize.c
@@ -1,4 +1,4 @@
-long os_getpagesize()
+long os_getpagesize(void)
 {
     return 4096; // guess, for now
 }

--- a/src/os/Win32/pagesize.c
+++ b/src/os/Win32/pagesize.c
@@ -1,3 +1,5 @@
+#include "os_common.h"
+
 long os_getpagesize(void)
 {
     return 4096; // guess, for now

--- a/src/os/default/pagesize.c
+++ b/src/os/default/pagesize.c
@@ -2,7 +2,7 @@
 
 #include <unistd.h>
 
-long os_getpagesize()
+long os_getpagesize(void)
 {
     return sysconf(_SC_PAGESIZE);
 }

--- a/src/tas.c
+++ b/src/tas.c
@@ -32,7 +32,7 @@ static const struct option longopts[] = {
     { NULL, 0, NULL, 0 },
 };
 
-static const char *version()
+static const char *version(void)
 {
     return "tas version " STR(BUILD_NAME) " built " __DATE__;
 }

--- a/src/tld.c
+++ b/src/tld.c
@@ -57,7 +57,7 @@ static const struct option longopts[] = {
     { NULL, 0, NULL, 0 },
 };
 
-static const char *version()
+static const char *version(void)
 {
     return "tld version " STR(BUILD_NAME) " built " __DATE__;
 }

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -556,7 +556,7 @@ int main(int argc, char *argv[])
     devices_teardown(s);
 
     if (s->conf.debugging > 0)
-        fprintf(stderr, "Instructions executed: %llu\n", s->insns_executed);
+        fprintf(stderr, "Instructions executed: %lu\n", (unsigned long)s->insns_executed);
 
 cleanup:
     param_destroy(s->conf.params);

--- a/src/tsim.c
+++ b/src/tsim.c
@@ -88,7 +88,7 @@ static const char *library_search_paths[] = {
     NULL
 };
 
-static const char *version()
+static const char *version(void)
 {
     return "tsim version " STR(BUILD_NAME) " built " __DATE__;
 }


### PR DESCRIPTION
Pull request #39 inadvertently made it impossible to build without `PEDANTIC` forced off even for modern GCC versions like 9.3.0. The current pull request detects `clang` and `gcc` heuristically and tries to get the best of both worlds while still maintaining a high level of pedantry.