### PR TITLE
Fix bugs relating to `tas` non-zero exits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected a long-standing tsim bug when right-shifting by more than 31 bits
 - Corrected tsim bugs manifesting on big-endian host machines
 - Corrected silent sign conversions, adhering to `-Werror=sign-conversion`
+- Prevented disassembly from `obj` from always exiting non-zero (#59)
 
 ### Removed
 - Stopped suggesting Gitter as a chat option

--- a/src/asm.c
+++ b/src/asm.c
@@ -316,7 +316,8 @@ static int obj_in(STREAM *stream, struct element *i, void *ud)
     int done = 0;
     while (!done) {
         if (!rec) {
-            u->error = 1;
+            // We have reached the end of the list. This is not an error
+            // condition, but we need to signal it specially.
             return -1;
         }
 

--- a/src/obj.c
+++ b/src/obj.c
@@ -260,6 +260,10 @@ static int get_recs(struct obj *o, STREAM *in, void *context)
     long *filesize = context;
 
     GET(o->rec_count, in);
+    if (o->rec_count < 0) {
+        errno = EINVAL;
+        return 1;
+    }
     if (o->rec_count > OBJ_MAX_REC_CNT) {
         errno = EFBIG;
         return 1;
@@ -317,6 +321,10 @@ static int get_syms_v1(struct obj *o, STREAM *in, void *context)
 static int get_syms_v2(struct obj *o, STREAM *in, void *context)
 {
     GET(o->sym_count, in);
+    if (o->sym_count < 0) {
+        errno = EINVAL;
+        return 1;
+    }
     if (o->sym_count > OBJ_MAX_SYMBOLS) {
         errno = EFBIG;
         return 1;
@@ -365,6 +373,10 @@ static int get_relocs_v0(struct obj *o, STREAM *in, void *context)
 static int get_relocs_v2(struct obj *o, STREAM *in, void *context)
 {
     GET(o->rlc_count, in);
+    if (o->rlc_count < 0) {
+        errno = EINVAL;
+        return 1;
+    }
     if (o->rlc_count > OBJ_MAX_RELOCS) {
         errno = EFBIG;
         return 1;


### PR DESCRIPTION
`tas` is meant to exit non-zero when some error exists, but it was exiting non-zero for all `tas -d` (disassembly) invocations that used the (default) `obj` input format.

Because of this, it was erroneously passing some negative tests that have also been fixed.