### PR TITLE
Fix build for Icarus Verilog 11.0

### DIFF
--- a/hw/icarus/Makefile
+++ b/hw/icarus/Makefile
@@ -22,6 +22,9 @@ vpath %.memh ../verilog
 VFLAGS += -I../verilog -g2005-sv
 VFLAGS += -DSIM
 
+# We use IVERILOG_VPI_MODULE_PATH rather than -L in order to maintain backward
+# compatibility with Icarus v10.
+tenyr: export IVERILOG_VPI_MODULE_PATH=$(BUILDDIR)
 tenyr: VFLAGS += -m vpidevices
 tenyr: VFLAGS += -DSIMMEM=GenedBlockMem -DSIMCLK=tenyr_mainclock
 tenyr: VFLAGS += -DSERIAL

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -244,9 +244,9 @@ test_run_%: %.texe $(build_tas) $(build_tld)
 	@$(MAKESTEP) -n "Running test `printf %-20s "'$*'"` ($(context)) ... "
 	$(run) && $(MAKESTEP) ok
 
-check_hw_icarus_pre:
+check_hw_icarus_pre: vpidevices.vpi
 	@$(MAKESTEP) -n "Building hardware simulator ... "
-	$(MAKE) $S -C $(TOP)/hw/icarus tenyr && $(MAKESTEP) ok
+	$(MAKE) $S -C $(TOP)/hw/icarus BUILDDIR=$(abspath $(BUILDDIR)) tenyr && $(MAKESTEP) ok
 
 tsim_FLAVOURS := interp interp_prealloc
 tsim_FLAGS_interp =


### PR DESCRIPTION
When Icarus Verilog was updated from 10.3 to 11.0, it changed the way that VPI modules are found. Now we explicitly search in the path where we build the `.vpi` file.

Additionally, the building of the VPI object was underconstrained, so the Makefile rules have been updated to require building `vpidevices.vpi` before attempting to run any other Icarus commands.

Finally, BUILDDIR was incorrectly passed as a broken relative path when building the Icarus `tenyr` executable, so this was corrected.
