### PR TITLE
Introduce CI with GitHub Actions

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,0 +1,24 @@
+name: C-language CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+env:
+  SDL: 0
+  JIT: 0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make -j
+      timeout-minutes: 1
+    - name: make check_sw
+      run: make check_sw
+      timeout-minutes: 5
+

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -18,6 +18,10 @@ jobs:
     - name: make
       run: make -j
       timeout-minutes: 1
+    - uses: actions/upload-artifact@v2
+      with:
+        path: build/
+        name: builddir-${{ matrix.os }}
     - name: make check_sw
       run: make check_sw
       timeout-minutes: 5

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -9,11 +9,21 @@ on:
 env:
   SDL: 0
   JIT: 0
+  PEDANTIC: 0
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
+    - if: runner.os == 'Linux'
+      run: sudo apt-get install expect # for unbuffer
+    - if: runner.os == 'macOS'
+      run: |
+        brew install bison expect
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
     - uses: actions/checkout@v2
     - name: make
       run: make -j
@@ -23,6 +33,6 @@ jobs:
         path: build/
         name: builddir-${{ matrix.os }}
     - name: make check_sw
-      run: make check_sw
+      run: unbuffer make check_sw
       timeout-minutes: 5
 


### PR DESCRIPTION
Introduce GitHub Actions for CI, since [Travis CI is no longer a long-term solution](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing).