### PR TITLE
Turn on CI testing of JIT using GNU Lightning

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -25,6 +25,12 @@ jobs:
         brew install bison expect
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
     - uses: actions/checkout@v2
+    - if: env.JIT != 0
+      run: |
+          ./scripts/build-lightning.sh 2.1.3 $HOME/local
+          echo "C_INCLUDE_PATH=$HOME/local/include" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=$HOME/local/lib" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/local/lib" >> $GITHUB_ENV
     - name: make
       run: make -j
       timeout-minutes: 1

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   SDL: 0
-  JIT: 0
+  JIT: 1
   PEDANTIC: 0
 
 jobs:


### PR DESCRIPTION
Following on from #66, we introduce JIT support to the GitHub Actions CI workflow.