### PR TITLE
Prefer sdl2-config over pkg-config

### DIFF
--- a/mk/os/vars/Win32.mk
+++ b/mk/os/vars/Win32.mk
@@ -22,7 +22,7 @@ URL_SDL2       = https://www.libsdl.org/release/SDL2-devel-2.0.4-mingw.tar.gz
 DL_DIR_SDL2       = $(TOP)/3rdparty/sdl2
 DL_DIR_SDL2_image = $(TOP)/3rdparty/sdl2
 
-SDL2_PKGCONFIG = PKG_CONFIG_PATH=$(TOP)/3rdparty/sdl2/$(MACHINE)/lib/pkgconfig pkg-config --define-variable=prefix=$(TOP)/3rdparty/sdl2/$(MACHINE)
+SDL2_CONFIG = PKG_CONFIG_PATH=$(TOP)/3rdparty/sdl2/$(MACHINE)/lib/pkgconfig pkg-config --define-variable=prefix=$(TOP)/3rdparty/sdl2/$(MACHINE)
 
 # Create Wine path for a given UNIX path
 os_path = z:$(subst /,\\,$1)

--- a/mk/os/vars/default.mk
+++ b/mk/os/vars/default.mk
@@ -3,7 +3,7 @@ CFLAGS_PIC += -fPIC
 PATH_SEP_CHAR=':'
 DYLIB_SUFFIX = .so
 EXE_SUFFIX =
-# Respect SDL2_PKGCONFIG from environment
-SDL2_PKGCONFIG ?= sdl2-config
+# Respect SDL2_CONFIG from environment
+SDL2_CONFIG ?= sdl2-config
 # Pass through path unchanged in default configuration
 os_path = $1

--- a/mk/os/vars/default.mk
+++ b/mk/os/vars/default.mk
@@ -4,6 +4,6 @@ PATH_SEP_CHAR=':'
 DYLIB_SUFFIX = .so
 EXE_SUFFIX =
 # Respect SDL2_PKGCONFIG from environment
-SDL2_PKGCONFIG ?= pkg-config
+SDL2_PKGCONFIG ?= sdl2-config
 # Pass through path unchanged in default configuration
 os_path = $1

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -1,12 +1,12 @@
 ifneq ($(SDL),0)
-sdl2_pkg_config ?= $(shell $(SDL2_PKGCONFIG) $1 $2)
+sdl2_config ?= $(shell $(SDL2_PKGCONFIG) $1 $2)
 PDEVICES_SDL += sdlled sdlvga
 PDEVICES += $(PDEVICES_SDL)
 # Mark SDL header includes as system includes to avoid subjecting them to full
 # pedantry
 libtenyrsdl%$(DYLIB_SUFFIX) $(PDEVICES_SDL:%=devices/%.d): \
-    CPPFLAGS += $(patsubst -I%,-isystem %,$(call sdl2_pkg_config,--cflags))
-libtenyrsdl%$(DYLIB_SUFFIX): LDLIBS += $(call sdl2_pkg_config,--libs) -lSDL2_image
+    CPPFLAGS += $(patsubst -I%,-isystem %,$(call sdl2_config,--cflags))
+libtenyrsdl%$(DYLIB_SUFFIX): LDLIBS += $(call sdl2_config,--libs) -lSDL2_image
 libtenyrsdlvga$(DYLIB_SUFFIX): | $(TOP)/rsrc/font10x15/invert.font10x15.png
 $(TOP)/rsrc/font10x15/%:
 	$(MAKE) -C $(@D) $(@F)

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -1,5 +1,5 @@
 ifneq ($(SDL),0)
-sdl2_config ?= $(shell $(SDL2_PKGCONFIG) $1 $2)
+sdl2_config ?= $(shell $(SDL2_CONFIG) $1 $2)
 PDEVICES_SDL += sdlled sdlvga
 PDEVICES += $(PDEVICES_SDL)
 # Mark SDL header includes as system includes to avoid subjecting them to full

--- a/mk/sdl.mk
+++ b/mk/sdl.mk
@@ -1,16 +1,12 @@
 ifneq ($(SDL),0)
 sdl2_pkg_config ?= $(shell $(SDL2_PKGCONFIG) $1 $2)
-SDL_VERSION := $(call sdl2_pkg_config,--modversion,sdl2)
-ifneq ($(SDL_VERSION),)
 PDEVICES_SDL += sdlled sdlvga
 PDEVICES += $(PDEVICES_SDL)
 # Mark SDL header includes as system includes to avoid subjecting them to full
 # pedantry
 libtenyrsdl%$(DYLIB_SUFFIX) $(PDEVICES_SDL:%=devices/%.d): \
-    CPPFLAGS += $(patsubst -I%,-isystem %,$(call sdl2_pkg_config,--cflags-only-I,sdl2 SDL2_image))
-libtenyrsdl%$(DYLIB_SUFFIX) $(PDEVICES_SDL:%=devices/%.d): \
-    CPPFLAGS += $(call sdl2_pkg_config,--cflags-only-other,sdl2 SDL2_image)
-libtenyrsdl%$(DYLIB_SUFFIX): LDLIBS += $(call sdl2_pkg_config,--libs,sdl2 SDL2_image)
+    CPPFLAGS += $(patsubst -I%,-isystem %,$(call sdl2_pkg_config,--cflags))
+libtenyrsdl%$(DYLIB_SUFFIX): LDLIBS += $(call sdl2_pkg_config,--libs) -lSDL2_image
 libtenyrsdlvga$(DYLIB_SUFFIX): | $(TOP)/rsrc/font10x15/invert.font10x15.png
 $(TOP)/rsrc/font10x15/%:
 	$(MAKE) -C $(@D) $(@F)
@@ -18,6 +14,5 @@ $(TOP)/rsrc/font10x15/%:
 # Do not halt the build for platforms on which the feature-flag _BSD_SOURCE is
 # unused.
 sdl%.o: CFLAGS += -W$(PEDANTRY_EXCEPTION)unused-macros -W'$(PEDANTRY_EXCEPTION)\#warnings'
-endif
 endif
 


### PR DESCRIPTION
The use of `pkg-config` to configure SDL2 is heavy-handed and results in installation of an extraneous dependency on macOS systems. Using `sdl2-config` instead reduces complexity and probably improves robustness.