### PR TITLE
Fix crash in SDLVGA on macOS Big Sur 11.2

### DIFF
--- a/src/devices/sdlvga.c
+++ b/src/devices/sdlvga.c
@@ -108,9 +108,9 @@ static int sdlvga_init(struct plugin_cookie *pcookie, struct device *device, voi
     SDL_FreeSurface(sprite);
 
     SDL_SetRenderDrawColor(state->renderer, 0, 0, 0, 255);
-    SDL_SetRenderTarget(state->renderer, state->display);
     SDL_RenderClear(state->renderer);
     SDL_RenderPresent(state->renderer);
+    SDL_SetRenderTarget(state->renderer, state->display);
 
     gettimeofday(&state->last_update, NULL);
     state->deadline = state->last_update;


### PR DESCRIPTION
On macOS Big Sur 11.2, a crash in sdlvga (but not sdlled) was noticed when running SDL with a non-dummy display. The underlying cause is not fully understood, but the new call order is consistent with the pre-existing call order in `handle_update`.