### PR TITLE
Enable GitHub Actions for macos-11 runners

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -66,7 +66,9 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os:
+        - ubuntu-18.04
+        - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - if: runner.os == 'Linux'

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -69,6 +69,7 @@ jobs:
         os:
         - ubuntu-18.04
         - macos-latest
+        - macos-11
     runs-on: ${{ matrix.os }}
     steps:
     - if: runner.os == 'Linux'


### PR DESCRIPTION
Since #85, and as of the closure of https://github.com/actions/virtual-environments/issues/2486, [macOS 11 Big Sur is generally available on GitHub-hosted runners][1] and so we will start using `macos-11` in our CI alongside `macos-latest`.

[1]: https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/