### PR TITLE
Fix CI for macOS runners

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -55,7 +55,15 @@ jobs:
         brew install bison expect icarus-verilog
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
     - if: runner.os == 'macOS' && env.SDL != 0
-      run: brew install sdl2 sdl2_image
+      run: |
+        brew install sdl2
+        # In SDL2_image 2.6.0, CMake support was added, but as of the current
+        # release 2.6.1, the Homebrew build does not yet work due to prefix
+        # computation that was fixed in
+        # https://github.com/libsdl-org/SDL_image/pull/295
+        # TODO stop installing from HEAD when a package with a fix (SDL2_image
+        # 2.6.2 perhaps?) is released.
+        brew install --HEAD sdl2_image
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -41,6 +41,9 @@ jobs:
         - macos-11
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
     - if: runner.os == 'Linux'
       run: sudo apt-get update
     - if: runner.os == 'Linux'

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -16,9 +16,15 @@ jobs:
   coverage:
     runs-on: ubuntu-20.04
     steps:
-    - run: sudo apt-get update
-    - run: sudo apt-get install expect iverilog lcov
-    - run: sudo apt-get install libsdl2-dev libsdl2-image-dev
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - run: brew install bison expect icarus-verilog
+    - if: env.SDL != 0
+      run: |
+        brew install sdl2
+        # See below for notes about `--HEAD` here.
+        brew install --HEAD sdl2_image
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -44,17 +50,10 @@ jobs:
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
-    - if: runner.os == 'Linux'
-      run: sudo apt-get update
-    - if: runner.os == 'Linux'
-      run: sudo apt-get install expect iverilog
-    - if: runner.os == 'Linux' && env.SDL != 0
-      run: sudo apt-get install libsdl2-dev libsdl2-image-dev
+    - run: brew install bison expect icarus-verilog
     - if: runner.os == 'macOS'
-      run: |
-        brew install bison expect icarus-verilog
-        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
-    - if: runner.os == 'macOS' && env.SDL != 0
+      run: echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+    - if: env.SDL != 0
       run: |
         brew install sdl2
         # In SDL2_image 2.6.0, CMake support was added, but as of the current

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -27,12 +27,9 @@ target_compile_options(
 )
 
 if(SDL)
-    include(FindPkgConfig)
+    find_package(SDL2 REQUIRED)
+    find_package(SDL2_image REQUIRED)
 
-    pkg_search_module(SDL2 REQUIRED sdl2)
-    pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
-
-    # TODO use find_package to set SDL build automatically.
     add_library(tenyrsdlled MODULE sdlled.c)
     target_link_libraries(tenyrsdlled PUBLIC common-pic)
     add_library(tenyrsdlvga MODULE sdlvga.c)
@@ -41,8 +38,6 @@ if(SDL)
     # Place libraries alongside the `tsim` binary in order to be found.
     set_target_properties(tenyrsdlled tenyrsdlvga PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src)
 
-    target_include_directories(tenyrsdlled PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2IMAGE_INCLUDE_DIRS})
-    target_link_libraries(tenyrsdlled PRIVATE ${SDL2_LINK_LIBRARIES} ${SDL2IMAGE_LINK_LIBRARIES})
-    target_include_directories(tenyrsdlvga PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2IMAGE_INCLUDE_DIRS})
-    target_link_libraries(tenyrsdlvga PRIVATE ${SDL2_LINK_LIBRARIES} ${SDL2IMAGE_LINK_LIBRARIES})
+    target_link_libraries(tenyrsdlled PRIVATE SDL2::SDL2 SDL2_image::SDL2_image)
+    target_link_libraries(tenyrsdlvga PRIVATE SDL2::SDL2 SDL2_image::SDL2_image)
 endif()


### PR DESCRIPTION
CI is failing for `macos-10.15`: https://github.com/kulp/tenyr/runs/7774158286

This PR seeks to rectify, or at least work around, the failures; it is a work in progress.