### PR TITLE
Use Homebrew and update CI

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -55,7 +55,15 @@ jobs:
         brew install bison expect icarus-verilog
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
     - if: runner.os == 'macOS' && env.SDL != 0
-      run: brew install sdl2 sdl2_image
+      run: |
+        brew install sdl2
+        # In SDL2_image 2.6.0, CMake support was added, but as of the current
+        # release 2.6.1, the Homebrew build does not yet work due to prefix
+        # computation that was fixed in
+        # https://github.com/libsdl-org/SDL_image/pull/295
+        # TODO stop installing from HEAD when a package with a fix (SDL2_image
+        # 2.6.2 perhaps?) is released.
+        brew install --HEAD sdl2_image
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Homebrew
       id: set-up-homebrew
@@ -42,9 +42,9 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-18.04
+        - ubuntu-latest
         - macos-10.15
-        - macos-11
+        - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Homebrew

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -41,6 +41,9 @@ jobs:
         - macos-11
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
     - if: runner.os == 'Linux'
       run: sudo apt-get update
     - if: runner.os == 'Linux'

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -16,9 +16,15 @@ jobs:
   coverage:
     runs-on: ubuntu-20.04
     steps:
-    - run: sudo apt-get update
-    - run: sudo apt-get install expect iverilog lcov
-    - run: sudo apt-get install libsdl2-dev libsdl2-image-dev
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - run: brew install bison expect icarus-verilog lcov
+    - if: env.SDL != 0
+      run: |
+        brew install sdl2
+        # See below for notes about `--HEAD` here.
+        brew install --HEAD sdl2_image
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -44,17 +50,10 @@ jobs:
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
-    - if: runner.os == 'Linux'
-      run: sudo apt-get update
-    - if: runner.os == 'Linux'
-      run: sudo apt-get install expect iverilog
-    - if: runner.os == 'Linux' && env.SDL != 0
-      run: sudo apt-get install libsdl2-dev libsdl2-image-dev
+    - run: brew install bison expect icarus-verilog
     - if: runner.os == 'macOS'
-      run: |
-        brew install bison expect icarus-verilog
-        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
-    - if: runner.os == 'macOS' && env.SDL != 0
+      run: echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+    - if: env.SDL != 0
       run: |
         brew install sdl2
         # In SDL2_image 2.6.0, CMake support was added, but as of the current

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -27,12 +27,9 @@ target_compile_options(
 )
 
 if(SDL)
-    include(FindPkgConfig)
+    find_package(SDL2 REQUIRED)
+    find_package(SDL2_image REQUIRED)
 
-    pkg_search_module(SDL2 REQUIRED sdl2)
-    pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
-
-    # TODO use find_package to set SDL build automatically.
     add_library(tenyrsdlled MODULE sdlled.c)
     target_link_libraries(tenyrsdlled PUBLIC common-pic)
     add_library(tenyrsdlvga MODULE sdlvga.c)
@@ -41,8 +38,6 @@ if(SDL)
     # Place libraries alongside the `tsim` binary in order to be found.
     set_target_properties(tenyrsdlled tenyrsdlvga PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src)
 
-    target_include_directories(tenyrsdlled PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2IMAGE_INCLUDE_DIRS})
-    target_link_libraries(tenyrsdlled PRIVATE ${SDL2_LINK_LIBRARIES} ${SDL2IMAGE_LINK_LIBRARIES})
-    target_include_directories(tenyrsdlvga PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2IMAGE_INCLUDE_DIRS})
-    target_link_libraries(tenyrsdlvga PRIVATE ${SDL2_LINK_LIBRARIES} ${SDL2IMAGE_LINK_LIBRARIES})
+    target_link_libraries(tenyrsdlled PRIVATE SDL2::SDL2 SDL2_image::SDL2_image)
+    target_link_libraries(tenyrsdlvga PRIVATE SDL2::SDL2 SDL2_image::SDL2_image)
 endif()

--- a/tests.cmake
+++ b/tests.cmake
@@ -336,7 +336,7 @@ set_tests_properties(
     PROPERTIES
     LABELS "tool=tas;expensive"
     COST 0.5
-    TIMEOUT 60
+    TIMEOUT 120
 )
 
 check_std_outputs(NAME "text disassembly"       COMMAND ${CMAKE_TENYR_COMPILER} ARGS -ftext -d)


### PR DESCRIPTION
Fixes #100.
Closes #101.
Closes #102.

CI was broken in a few ways, not all of which were understood. The current PR:
- uses Homebrew to install recent `SDL2_image` such that `find_package` can be used instead of depending on `FindPkgConfig`
- stops hard-coding versions for `ubuntu-18.04` and `ubuntu-20.04`
- uses `macos-latest` instead of `macos-11` (while keeping `macos-10.15`)
- bumps upward a timeout for the `dogfood` test that was apparently on the ragged edge of succeeding